### PR TITLE
Pin images to :v20190401-6a7e3ff

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,7 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "quay.io/pusher/clonerefs:latest"
+      clonerefs: "quay.io/pusher/clonerefs:v20190401-6a7e3ff"
       initupload: "gcr.io/k8s-prow/initupload:v20190301-2d35634"
       entrypoint: "gcr.io/k8s-prow/entrypoint:v20190301-2d35634"
       sidecar: "gcr.io/k8s-prow/sidecar:v20190301-2d35634"

--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: verify-generate
             command: ["/usr/local/bin/runner"]
             args:
@@ -30,7 +30,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: verify-manifests
             command: ["/usr/local/bin/runner"]
             args:
@@ -51,7 +51,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: lint
             command: ["/usr/local/bin/runner"]
             args:
@@ -72,7 +72,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: test-ginkgo
             command: ["/usr/local/bin/runner"]
             args:
@@ -95,7 +95,7 @@ presubmits:
         preset-dind-enabled: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:latest
+          - image: quay.io/pusher/builder:v20190401-6a7e3ff
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/testing/testing-postsubmits.yaml
+++ b/config/jobs/testing/testing-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
         preset-quay-credentials: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:latest
+          - image: quay.io/pusher/builder:v20190401-6a7e3ff
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder:latest
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: verify-config
             command: ["/usr/local/bin/runner"]
             args:
@@ -33,7 +33,7 @@ presubmits:
         preset-quay-credentials: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:latest
+          - image: quay.io/pusher/builder:v20190401-6a7e3ff
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/wave/wave-presubmits.yaml
+++ b/config/jobs/wave/wave-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: verify-generate
             command: ["/usr/local/bin/runner"]
             args:
@@ -30,7 +30,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: verify-manifests
             command: ["/usr/local/bin/runner"]
             args:
@@ -51,7 +51,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: lint
             command: ["/usr/local/bin/runner"]
             args:
@@ -72,7 +72,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder
+          - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
             name: test-ginkgo
             command: ["/usr/local/bin/runner"]
             args:
@@ -95,7 +95,7 @@ presubmits:
         preset-dind-enabled: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:latest
+          - image: quay.io/pusher/builder:v20190401-6a7e3ff
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17,7 +17,7 @@ data:
         timeout: 7200000000000 # 2h
         grace_period: 15000000000 # 15s
         utility_images:
-          clonerefs: "quay.io/pusher/clonerefs:latest"
+          clonerefs: "quay.io/pusher/clonerefs:v20190401-6a7e3ff"
           initupload: "gcr.io/k8s-prow/initupload:v20190301-2d35634"
           entrypoint: "gcr.io/k8s-prow/entrypoint:v20190301-2d35634"
           sidecar: "gcr.io/k8s-prow/sidecar:v20190301-2d35634"

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -18,7 +18,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: verify-generate
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -39,7 +39,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: verify-manifests
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -60,7 +60,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: lint
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -81,7 +81,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: test-ginkgo
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -104,7 +104,7 @@ data:
             preset-dind-enabled: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:latest
+              - image: quay.io/pusher/builder:v20190401-6a7e3ff
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -136,7 +136,7 @@ data:
             preset-quay-credentials: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:latest
+              - image: quay.io/pusher/builder:v20190401-6a7e3ff
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -159,7 +159,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder:latest
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: verify-config
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -183,7 +183,7 @@ data:
             preset-quay-credentials: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:latest
+              - image: quay.io/pusher/builder:v20190401-6a7e3ff
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -208,7 +208,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: verify-generate
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -229,7 +229,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: verify-manifests
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -250,7 +250,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: lint
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -271,7 +271,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder
+              - image: quay.io/pusher/kubebuilder-builder:v20190401-6a7e3ff
                 name: test-ginkgo
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -294,7 +294,7 @@ data:
             preset-dind-enabled: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:latest
+              - image: quay.io/pusher/builder:v20190401-6a7e3ff
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:


### PR DESCRIPTION
This pins all images to `:v20190401-6a7e3ff` which was the result of merging #2 into `master`. 

All references to Pusher `(.*)?builder` and `clonerefs` images should now be pinned