### PR TITLE
Remove superfluous push-latest

### DIFF
--- a/config/jobs/testing/testing-postsubmits.yaml
+++ b/config/jobs/testing/testing-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:
-              - make --directory=images push push-latest
+              - make --directory=images push
             resources:
               requests:
                 cpu: 1

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -140,7 +140,7 @@ data:
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
-                  - make --directory=images push push-latest
+                  - make --directory=images push
                 resources:
                   requests:
                     cpu: 1


### PR DESCRIPTION
This is a relic from before I reworked the push to use environment variables for the tags and therefore is no longer necessary