### PR TITLE
Add multi K8s version tests for Faros

### DIFF
--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -79,8 +79,8 @@ presubmits:
               - touch .env && make prepare-env-1.13 && make test
             resources:
               requests:
-                cpu: 1
-                memory: 1Gi
+                cpu: 3
+                memory: 2Gi
       trigger: "(?m)^/test (?:.*? )?(1.13|all)(?: .*?)?$"
       rerun_command: "/test 1.13"
 
@@ -100,8 +100,8 @@ presubmits:
               - touch .env && make prepare-env-1.12 && SKIP_DRY_RUN_TESTS=true make test
             resources:
               requests:
-                cpu: 1
-                memory: 1Gi
+                cpu: 3
+                memory: 2Gi
       trigger: "(?m)^/test (?:.*? )?(1.12|all)(?: .*?)?$"
       rerun_command: "/test 1.12"
 
@@ -121,8 +121,8 @@ presubmits:
               - touch .env && make prepare-env-1.11 && SKIP_DRY_RUN_TESTS=true make test
             resources:
               requests:
-                cpu: 1
-                memory: 1Gi
+                cpu: 3
+                memory: 2Gi
       trigger: "(?m)^/test (?:.*? )?(1.11|all)(?: .*?)?$"
       rerun_command: "/test 1.11"
 

--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -97,7 +97,7 @@ presubmits:
             name: test-ginkgo
             command: ["/usr/local/bin/runner"]
             args:
-              - touch .env && make prepare-env-1.12 && make test
+              - touch .env && make prepare-env-1.12 && SKIP_DRY_RUN_TESTS=true make test
             resources:
               requests:
                 cpu: 1
@@ -118,7 +118,7 @@ presubmits:
             name: test-ginkgo
             command: ["/usr/local/bin/runner"]
             args:
-              - touch .env && make prepare-env-1.11 && make test
+              - touch .env && make prepare-env-1.11 && SKIP_DRY_RUN_TESTS=true make test
             resources:
               requests:
                 cpu: 1

--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -18,8 +18,8 @@ presubmits:
               requests:
                 cpu: 1
                 memory: 1Gi
-      trigger: "(?m)^/verify generate,?(\\s+|$)"
-      rerun_command: "/verify generate"
+      trigger: "(?m)^/test (?:.*? )?(verify-generate|all)(?: .*?)?$"
+      rerun_command: "/test verify-generate"
 
     - name: pull-faros-verify-manifests
       max_concurrency: 10
@@ -39,8 +39,8 @@ presubmits:
               requests:
                 cpu: 1
                 memory: 1Gi
-      trigger: "(?m)^/verify manifests,?(\\s+|$)"
-      rerun_command: "/verify manifests"
+      trigger: "(?m)^/test (?:.*? )?(verify-manifests|all)(?: .*?)?$"
+      rerun_command: "/test verify-manifests"
 
     - name: pull-faros-lint
       max_concurrency: 10
@@ -60,10 +60,10 @@ presubmits:
               requests:
                 cpu: 1
                 memory: 1Gi
-      trigger: "(?m)^/lint,?(\\s+|$)"
-      rerun_command: "/lint"
+      trigger: "(?m)^/test (?:.*? )?(lint|all)(?:.*? )?$"
+      rerun_command: "/test lint"
 
-    - name: pull-faros-test-ginkgo
+    - name: pull-faros-test-1.13
       max_concurrency: 10
       path_alias: github.com/pusher/faros
       agent: kubernetes
@@ -81,8 +81,50 @@ presubmits:
               requests:
                 cpu: 1
                 memory: 1Gi
-      trigger: "(?m)^/test ginkgo,?(\\s+|$)"
-      rerun_command: "/test ginkgo"
+      trigger: "(?m)^/test (?:.*? )?(1.13|all)(?: .*?)?$"
+      rerun_command: "/test 1.13"
+
+    - name: pull-faros-test-1.12
+      max_concurrency: 10
+      path_alias: github.com/pusher/faros
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+      spec:
+        containers:
+          - image: quay.io/pusher/kubebuilder-builder
+            name: test-ginkgo
+            command: ["/usr/local/bin/runner"]
+            args:
+              - touch .env && make prepare-env-1.12 && make test
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+      trigger: "(?m)^/test (?:.*? )?(1.12|all)(?: .*?)?$"
+      rerun_command: "/test 1.12"
+
+    - name: pull-faros-test-1.11
+      max_concurrency: 10
+      path_alias: github.com/pusher/faros
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+      spec:
+        containers:
+          - image: quay.io/pusher/kubebuilder-builder
+            name: test-ginkgo
+            command: ["/usr/local/bin/runner"]
+            args:
+              - touch .env && make prepare-env-1.11 && make test
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+      trigger: "(?m)^/test (?:.*? )?(1.11|all)(?: .*?)?$"
+      rerun_command: "/test 1.11"
 
     - name: pull-faros-build-docker
       max_concurrency: 10
@@ -109,5 +151,5 @@ presubmits:
                 memory: 1Gi
             securityContext:
               privileged: true
-      trigger: "(?m)^/build docker,?(\\s+|$)"
+      trigger: "(?m)^/build (?:.*? )?(docker|all)(?: .*?)?$"
       rerun_command: "/build docker"

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -27,8 +27,8 @@ data:
                   requests:
                     cpu: 1
                     memory: 1Gi
-          trigger: "(?m)^/verify generate,?(\\s+|$)"
-          rerun_command: "/verify generate"
+          trigger: "(?m)^/test (?:.*? )?(verify-generate|all)(?: .*?)?$"
+          rerun_command: "/test verify-generate"
 
         - name: pull-faros-verify-manifests
           max_concurrency: 10
@@ -48,8 +48,8 @@ data:
                   requests:
                     cpu: 1
                     memory: 1Gi
-          trigger: "(?m)^/verify manifests,?(\\s+|$)"
-          rerun_command: "/verify manifests"
+          trigger: "(?m)^/test (?:.*? )?(verify-manifests|all)(?: .*?)?$"
+          rerun_command: "/test verify-manifests"
 
         - name: pull-faros-lint
           max_concurrency: 10
@@ -69,10 +69,10 @@ data:
                   requests:
                     cpu: 1
                     memory: 1Gi
-          trigger: "(?m)^/lint,?(\\s+|$)"
-          rerun_command: "/lint"
+          trigger: "(?m)^/test (?:.*? )?(lint|all)(?:.*? )?$"
+          rerun_command: "/test lint"
 
-        - name: pull-faros-test-ginkgo
+        - name: pull-faros-test-1.13
           max_concurrency: 10
           path_alias: github.com/pusher/faros
           agent: kubernetes
@@ -90,8 +90,50 @@ data:
                   requests:
                     cpu: 1
                     memory: 1Gi
-          trigger: "(?m)^/test ginkgo,?(\\s+|$)"
-          rerun_command: "/test ginkgo"
+          trigger: "(?m)^/test (?:.*? )?(1.13|all)(?: .*?)?$"
+          rerun_command: "/test 1.13"
+
+        - name: pull-faros-test-1.12
+          max_concurrency: 10
+          path_alias: github.com/pusher/faros
+          agent: kubernetes
+          always_run: true
+          skip_report: false
+          decorate: true
+          spec:
+            containers:
+              - image: quay.io/pusher/kubebuilder-builder
+                name: test-ginkgo
+                command: ["/usr/local/bin/runner"]
+                args:
+                  - touch .env && make prepare-env-1.12 && make test
+                resources:
+                  requests:
+                    cpu: 1
+                    memory: 1Gi
+          trigger: "(?m)^/test (?:.*? )?(1.12|all)(?: .*?)?$"
+          rerun_command: "/test 1.12"
+
+        - name: pull-faros-test-1.11
+          max_concurrency: 10
+          path_alias: github.com/pusher/faros
+          agent: kubernetes
+          always_run: true
+          skip_report: false
+          decorate: true
+          spec:
+            containers:
+              - image: quay.io/pusher/kubebuilder-builder
+                name: test-ginkgo
+                command: ["/usr/local/bin/runner"]
+                args:
+                  - touch .env && make prepare-env-1.11 && make test
+                resources:
+                  requests:
+                    cpu: 1
+                    memory: 1Gi
+          trigger: "(?m)^/test (?:.*? )?(1.11|all)(?: .*?)?$"
+          rerun_command: "/test 1.11"
 
         - name: pull-faros-build-docker
           max_concurrency: 10
@@ -118,7 +160,7 @@ data:
                     memory: 1Gi
                 securityContext:
                   privileged: true
-          trigger: "(?m)^/build docker,?(\\s+|$)"
+          trigger: "(?m)^/build (?:.*? )?(docker|all)(?: .*?)?$"
           rerun_command: "/build docker"
   testing_testing-postsubmits.yaml: |
     postsubmits:

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -106,7 +106,7 @@ data:
                 name: test-ginkgo
                 command: ["/usr/local/bin/runner"]
                 args:
-                  - touch .env && make prepare-env-1.12 && make test
+                  - touch .env && make prepare-env-1.12 && SKIP_DRY_RUN_TESTS=true make test
                 resources:
                   requests:
                     cpu: 1
@@ -127,7 +127,7 @@ data:
                 name: test-ginkgo
                 command: ["/usr/local/bin/runner"]
                 args:
-                  - touch .env && make prepare-env-1.11 && make test
+                  - touch .env && make prepare-env-1.11 && SKIP_DRY_RUN_TESTS=true make test
                 resources:
                   requests:
                     cpu: 1

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -88,8 +88,8 @@ data:
                   - touch .env && make prepare-env-1.13 && make test
                 resources:
                   requests:
-                    cpu: 1
-                    memory: 1Gi
+                    cpu: 3
+                    memory: 2Gi
           trigger: "(?m)^/test (?:.*? )?(1.13|all)(?: .*?)?$"
           rerun_command: "/test 1.13"
 
@@ -109,8 +109,8 @@ data:
                   - touch .env && make prepare-env-1.12 && SKIP_DRY_RUN_TESTS=true make test
                 resources:
                   requests:
-                    cpu: 1
-                    memory: 1Gi
+                    cpu: 3
+                    memory: 2Gi
           trigger: "(?m)^/test (?:.*? )?(1.12|all)(?: .*?)?$"
           rerun_command: "/test 1.12"
 
@@ -130,8 +130,8 @@ data:
                   - touch .env && make prepare-env-1.11 && SKIP_DRY_RUN_TESTS=true make test
                 resources:
                   requests:
-                    cpu: 1
-                    memory: 1Gi
+                    cpu: 3
+                    memory: 2Gi
           trigger: "(?m)^/test (?:.*? )?(1.11|all)(?: .*?)?$"
           rerun_command: "/test 1.11"
 


### PR DESCRIPTION
This adds testing for K8s 1.11 and 1.12 to Faros so we can check our backwards compatibility.

The 1.12 tests at the moment I know don't pass due to issues with our DryRun that need investigating.

I've also reworked the test commands and their regexes so that you can now chain multiple together (eg `/test 1.11 1.12`) or just say `/test all` to run all the tests.