### PR TITLE
Check whether gcloud exists or not

### DIFF
--- a/images/builder/runner
+++ b/images/builder/runner
@@ -79,7 +79,7 @@ set +o errexit
 # add $GOPATH/bin to $PATH
 export PATH=${GOPATH}/bin:${PATH}
 # Authenticate gcloud, allow failures
-if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && which gcloud &> /dev/null; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
 fi
 


### PR DESCRIPTION
Mainly to get rid off this slightly annoying and confusing error message:

```
/usr/local/bin/runner: line 83: gcloud: command not found
```