### PR TITLE
Fix favicon path

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,7 @@ sinker:
 deck:
   branding:
     logo: "/static/extensions/logo.svg"
-    favicon: "/static/extensions/favicon.ico"
+    favicon: "extensions/favicon.ico"
     header_color: "#300D4F"
   spyglass:
     size_limit: 500000000

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -34,7 +34,7 @@ data:
     deck:
       branding:
         logo: "/static/extensions/logo.svg"
-        favicon: "/static/extensions/favicon.ico"
+        favicon: "extensions/favicon.ico"
         header_color: "#300D4F"
       spyglass:
         size_limit: 500000000


### PR DESCRIPTION
Favicon logo got broken at some point, this is currently deployed and now works again 

Live -> ![favicon.ico](https://prow.pusher.com/favicon.ico)