### PR TITLE
 Add Pre/PostSubmits for K8s-Spot-Rescheduler

### DIFF
--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
@@ -1,0 +1,44 @@
+job_template: &job_template
+  max_concurrency: 10
+  path_alias: github.com/pusher/k8s-spot-rescheduler
+  agent: kubernetes
+  always_run: true
+  skip_report: false
+  decorate: true
+  branches:
+    - master
+    # Abuse Prow to make it run on tag pushes like v1.2.3 and v1.2.3-rc1
+    - ^v?\d+\.\d+\.\d+(-rc\d+)?$
+
+container_template: &container_template
+  image: quay.io/pusher/golang-builder:v20190404-3ebb4c5
+  name: runner
+  command: ["/usr/local/bin/runner"]
+
+container_template_large: &container_template_large
+  <<: *container_template
+  resources:
+    requests:
+      cpu: 4
+      memory: 4Gi
+    limits:
+      cpu: 8
+      memory: 8Gi
+
+postsubmits:
+  pusher/k8s-spot-rescheduler:
+    - name: post-k8s-spot-rescheduler-build-docker
+      <<: *job_template
+      labels:
+        preset-dind-enabled: "true"
+        preset-quay-credentials: "true"
+      spec:
+        containers:
+          - <<: *container_template_large
+            args:
+              - touch .env; # No config necessary
+              - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
+              - PUSH_TAGS=${TAGS}
+              - touch .env && make docker-build docker-tag docker-push
+            securityContext:
+              privileged: true

--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-presubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-presubmits.yaml
@@ -1,0 +1,83 @@
+job_template: &job_template
+  max_concurrency: 10
+  path_alias: github.com/pusher/k8s-spot-rescheduler
+  agent: kubernetes
+  always_run: true
+  skip_report: false
+  decorate: true
+
+container_template: &container_template
+  image: quay.io/pusher/golang-builder:v20190404-3ebb4c5
+  name: runner
+  command: ["/usr/local/bin/runner"]
+
+container_template_small: &container_template_small
+  <<: *container_template
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi
+
+container_template_large: &container_template_large
+  <<: *container_template
+  resources:
+    requests:
+      cpu: 4
+      memory: 4Gi
+    limits:
+      cpu: 8
+      memory: 8Gi
+
+presubmits:
+  pusher/k8s-spot-rescheduler:
+    - name: pull-k8s-spot-rescheduler-lint
+      <<: *job_template
+      spec:
+        containers:
+          - <<: *container_template_small
+            args:
+              - ./configure && make fmt vet lint
+      trigger: "(?m)^/test (?:.*? )?(lint|all)(?:.*? )?$"
+      rerun_command: "/test lint"
+
+    - name: pull-k8s-spot-rescheduler-build
+      <<: *job_template
+      spec:
+        containers:
+          - <<: *container_template_small
+            args:
+              - ./configure && make build
+      trigger: "(?m)^/test (?:.*? )?(build|all)(?:.*? )?$"
+      rerun_command: "/test build"
+
+    - name: pull-k8s-spot-rescheduler-tests
+      <<: *job_template
+      spec:
+        containers:
+          - <<: *container_template_small
+            args:
+              - ./configure && make test
+      trigger: "(?m)^/test (?:.*? )?(tests|all)(?: .*?)?$"
+      rerun_command: "/test tests"
+
+    - name: pull-k8s-spot-rescheduler-build-docker
+      <<: *job_template
+      always_run: false
+      labels:
+        preset-dind-enabled: "true"
+        preset-quay-credentials: "true"
+      spec:
+        containers:
+          - <<: *container_template_large
+            args:
+              - ./configure;
+              - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
+              - PUSH_TAGS=${TAGS}
+              - make docker-build docker-tag docker-push
+            securityContext:
+              privileged: true
+      trigger: "(?m)^/build (?:.*? )?(docker|all)(?: .*?)?$"
+      rerun_command: "/build docker"

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -1,10 +1,11 @@
 triggers:
   - repos:
-      - pusher/testing
       - pusher/faros
-      - pusher/wave
       - pusher/istio
+      - pusher/k8s-spot-rescheduler
       - pusher/prom-rule-reloader
+      - pusher/testing
+      - pusher/wave
     trusted_org: pusher
     only_org_members: true
   - repos:
@@ -27,8 +28,9 @@ default_plugins: &default_plugins
 - wip
 
 plugins:
-  pusher/testing: *default_plugins
   pusher/faros: *default_plugins
-  pusher/wave: *default_plugins
   pusher/istio: *default_plugins
+  pusher/k8s-spot-rescheduler: *default_plugins
   pusher/prom-rule-reloader: *default_plugins
+  pusher/testing: *default_plugins
+  pusher/wave: *default_plugins

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -556,6 +556,135 @@ data:
               command:
               - entrypoint
               - prow/e2e_pilotv2_auth_sds.sh
+  k8s-spot-rescheduler_k8s-spot-rescheduler-postsubmits.yaml: |
+    job_template: &job_template
+      max_concurrency: 10
+      path_alias: github.com/pusher/k8s-spot-rescheduler
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+      branches:
+        - master
+        # Abuse Prow to make it run on tag pushes like v1.2.3 and v1.2.3-rc1
+        - ^v?\d+\.\d+\.\d+(-rc\d+)?$
+
+    container_template: &container_template
+      image: quay.io/pusher/golang-builder:v20190404-3ebb4c5
+      name: runner
+      command: ["/usr/local/bin/runner"]
+
+    container_template_large: &container_template_large
+      <<: *container_template
+      resources:
+        requests:
+          cpu: 4
+          memory: 4Gi
+        limits:
+          cpu: 8
+          memory: 8Gi
+
+    postsubmits:
+      pusher/k8s-spot-rescheduler:
+        - name: post-k8s-spot-rescheduler-build-docker
+          <<: *job_template
+          labels:
+            preset-dind-enabled: "true"
+            preset-quay-credentials: "true"
+          spec:
+            containers:
+              - <<: *container_template_large
+                args:
+                  - touch .env; # No config necessary
+                  - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
+                  - PUSH_TAGS=${TAGS}
+                  - touch .env && make docker-build docker-tag docker-push
+                securityContext:
+                  privileged: true
+  k8s-spot-rescheduler_k8s-spot-rescheduler-presubmits.yaml: |
+    job_template: &job_template
+      max_concurrency: 10
+      path_alias: github.com/pusher/k8s-spot-rescheduler
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+
+    container_template: &container_template
+      image: quay.io/pusher/golang-builder:v20190404-3ebb4c5
+      name: runner
+      command: ["/usr/local/bin/runner"]
+
+    container_template_small: &container_template_small
+      <<: *container_template
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+        limits:
+          cpu: 2
+          memory: 2Gi
+
+    container_template_large: &container_template_large
+      <<: *container_template
+      resources:
+        requests:
+          cpu: 4
+          memory: 4Gi
+        limits:
+          cpu: 8
+          memory: 8Gi
+
+    presubmits:
+      pusher/k8s-spot-rescheduler:
+        - name: pull-k8s-spot-rescheduler-lint
+          <<: *job_template
+          spec:
+            containers:
+              - <<: *container_template_small
+                args:
+                  - ./configure && make fmt vet lint
+          trigger: "(?m)^/test (?:.*? )?(lint|all)(?:.*? )?$"
+          rerun_command: "/test lint"
+
+        - name: pull-k8s-spot-rescheduler-build
+          <<: *job_template
+          spec:
+            containers:
+              - <<: *container_template_small
+                args:
+                  - ./configure && make build
+          trigger: "(?m)^/test (?:.*? )?(build|all)(?:.*? )?$"
+          rerun_command: "/test build"
+
+        - name: pull-k8s-spot-rescheduler-tests
+          <<: *job_template
+          spec:
+            containers:
+              - <<: *container_template_small
+                args:
+                  - ./configure && make test
+          trigger: "(?m)^/test (?:.*? )?(tests|all)(?: .*?)?$"
+          rerun_command: "/test tests"
+
+        - name: pull-k8s-spot-rescheduler-build-docker
+          <<: *job_template
+          always_run: false
+          labels:
+            preset-dind-enabled: "true"
+            preset-quay-credentials: "true"
+          spec:
+            containers:
+              - <<: *container_template_large
+                args:
+                  - ./configure;
+                  - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
+                  - PUSH_TAGS=${TAGS}
+                  - make docker-build docker-tag docker-push
+                securityContext:
+                  privileged: true
+          trigger: "(?m)^/build (?:.*? )?(docker|all)(?: .*?)?$"
+          rerun_command: "/build docker"
   prom-rule-reloader_prom-rule-reloader-postsubmits.yaml: |
     job_template: &job_template
       max_concurrency: 10

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -9,11 +9,12 @@ data:
   plugins.yaml: |
     triggers:
       - repos:
-          - pusher/testing
           - pusher/faros
-          - pusher/wave
           - pusher/istio
+          - pusher/k8s-spot-rescheduler
           - pusher/prom-rule-reloader
+          - pusher/testing
+          - pusher/wave
         trusted_org: pusher
         only_org_members: true
       - repos:
@@ -36,11 +37,12 @@ data:
     - wip
 
     plugins:
-      pusher/testing: *default_plugins
       pusher/faros: *default_plugins
-      pusher/wave: *default_plugins
       pusher/istio: *default_plugins
+      pusher/k8s-spot-rescheduler: *default_plugins
       pusher/prom-rule-reloader: *default_plugins
+      pusher/testing: *default_plugins
+      pusher/wave: *default_plugins
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Adds a lint and test step for CI for the https://github.com/pusher/k8s-spot-rescheduler

Also alphabetised the repos in `plugins.yaml` since the list is growing