### PR TITLE
 Add k8s-spot-price-monitor Pre/Postsubmits

### DIFF
--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder
+  image: quay.io/pusher/python-builder:pull-17
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
@@ -1,0 +1,43 @@
+job_template: &job_template
+  max_concurrency: 10
+  path_alias: github.com/pusher/k8s-spot-price-monitor
+  agent: kubernetes
+  always_run: true
+  skip_report: false
+  decorate: true
+  branches:
+    - master
+    # Abuse Prow to make it run on tag pushes like v1.2.3 and v1.2.3-rc1
+    - ^v?\d+\.\d+\.\d+(-rc\d+)?$
+
+container_template: &container_template
+  image: quay.io/pusher/python-builder
+  name: runner
+  command: ["/usr/local/bin/runner"]
+
+container_template_large: &container_template_large
+  <<: *container_template
+  resources:
+    requests:
+      cpu: 4
+      memory: 4Gi
+    limits:
+      cpu: 8
+      memory: 8Gi
+
+postsubmits:
+  pusher/k8s-spot-price-monitor:
+    - name: post-k8s-spot-price-monitor-build-docker
+      <<: *job_template
+      labels:
+        preset-dind-enabled: "true"
+        preset-quay-credentials: "true"
+      spec:
+        containers:
+          - <<: *container_template_large
+            args:
+              - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
+              - PUSH_TAGS=${TAGS}
+              - make docker-push
+            securityContext:
+              privileged: true

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder
+  image: quay.io/pusher/python-builder:pull-17
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
@@ -1,0 +1,62 @@
+job_template: &job_template
+  max_concurrency: 10
+  path_alias: github.com/pusher/k8s-spot-price-monitor
+  agent: kubernetes
+  always_run: true
+  skip_report: false
+  decorate: true
+
+container_template: &container_template
+  image: quay.io/pusher/python-builder
+  name: runner
+  command: ["/usr/local/bin/runner"]
+
+container_template_small: &container_template_small
+  <<: *container_template
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi
+
+container_template_large: &container_template_large
+  <<: *container_template
+  resources:
+    requests:
+      cpu: 4
+      memory: 4Gi
+    limits:
+      cpu: 8
+      memory: 8Gi
+
+presubmits:
+  pusher/k8s-spot-price-monitor:
+    - name: pull-k8s-spot-price-monitor-lint
+      <<: *job_template
+      spec:
+        containers:
+          - <<: *container_template_small
+            args:
+              - make lint
+      trigger: "(?m)^/test (?:.*? )?(lint|all)(?:.*? )?$"
+      rerun_command: "/test lint"
+
+    - name: pull-k8s-spot-price-monitor-build-docker
+      <<: *job_template
+      always_run: false
+      labels:
+        preset-dind-enabled: "true"
+        preset-quay-credentials: "true"
+      spec:
+        containers:
+          - <<: *container_template_large
+            args:
+              - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
+              - PUSH_TAGS=${TAGS}
+              - make docker-push
+            securityContext:
+              privileged: true
+      trigger: "(?m)^/build (?:.*? )?(docker|all)(?: .*?)?$"
+      rerun_command: "/build docker"

--- a/config/plugins.yaml
+++ b/config/plugins.yaml
@@ -3,6 +3,7 @@ triggers:
       - pusher/faros
       - pusher/git-store
       - pusher/istio
+      - pusher/k8s-spot-price-monitor
       - pusher/k8s-spot-rescheduler
       - pusher/prom-rule-reloader
       - pusher/testing
@@ -32,6 +33,7 @@ plugins:
   pusher/faros: *default_plugins
   pusher/git-store: *default_plugins
   pusher/istio: *default_plugins
+  pusher/k8s-spot-price-monitor: *default_plugins
   pusher/k8s-spot-rescheduler: *default_plugins
   pusher/prom-rule-reloader: *default_plugins
   pusher/testing: *default_plugins

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -615,7 +615,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder
+      image: quay.io/pusher/python-builder:pull-17
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -655,7 +655,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder
+      image: quay.io/pusher/python-builder:pull-17
       name: runner
       command: ["/usr/local/bin/runner"]
 

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -601,6 +601,113 @@ data:
               command:
               - entrypoint
               - prow/e2e_pilotv2_auth_sds.sh
+  k8s-spot-price-monitor_k8s-spot-price-monitor-postsubmits.yaml: |
+    job_template: &job_template
+      max_concurrency: 10
+      path_alias: github.com/pusher/k8s-spot-price-monitor
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+      branches:
+        - master
+        # Abuse Prow to make it run on tag pushes like v1.2.3 and v1.2.3-rc1
+        - ^v?\d+\.\d+\.\d+(-rc\d+)?$
+
+    container_template: &container_template
+      image: quay.io/pusher/python-builder
+      name: runner
+      command: ["/usr/local/bin/runner"]
+
+    container_template_large: &container_template_large
+      <<: *container_template
+      resources:
+        requests:
+          cpu: 4
+          memory: 4Gi
+        limits:
+          cpu: 8
+          memory: 8Gi
+
+    postsubmits:
+      pusher/k8s-spot-price-monitor:
+        - name: post-k8s-spot-price-monitor-build-docker
+          <<: *job_template
+          labels:
+            preset-dind-enabled: "true"
+            preset-quay-credentials: "true"
+          spec:
+            containers:
+              - <<: *container_template_large
+                args:
+                  - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
+                  - PUSH_TAGS=${TAGS}
+                  - make docker-push
+                securityContext:
+                  privileged: true
+  k8s-spot-price-monitor_k8s-spot-price-monitor-presubmits.yaml: |
+    job_template: &job_template
+      max_concurrency: 10
+      path_alias: github.com/pusher/k8s-spot-price-monitor
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+
+    container_template: &container_template
+      image: quay.io/pusher/python-builder
+      name: runner
+      command: ["/usr/local/bin/runner"]
+
+    container_template_small: &container_template_small
+      <<: *container_template
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+        limits:
+          cpu: 2
+          memory: 2Gi
+
+    container_template_large: &container_template_large
+      <<: *container_template
+      resources:
+        requests:
+          cpu: 4
+          memory: 4Gi
+        limits:
+          cpu: 8
+          memory: 8Gi
+
+    presubmits:
+      pusher/k8s-spot-price-monitor:
+        - name: pull-k8s-spot-price-monitor-lint
+          <<: *job_template
+          spec:
+            containers:
+              - <<: *container_template_small
+                args:
+                  - make lint
+          trigger: "(?m)^/test (?:.*? )?(lint|all)(?:.*? )?$"
+          rerun_command: "/test lint"
+
+        - name: pull-k8s-spot-price-monitor-build-docker
+          <<: *job_template
+          always_run: false
+          labels:
+            preset-dind-enabled: "true"
+            preset-quay-credentials: "true"
+          spec:
+            containers:
+              - <<: *container_template_large
+                args:
+                  - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
+                  - PUSH_TAGS=${TAGS}
+                  - make docker-push
+                securityContext:
+                  privileged: true
+          trigger: "(?m)^/build (?:.*? )?(docker|all)(?: .*?)?$"
+          rerun_command: "/build docker"
   k8s-spot-rescheduler_k8s-spot-rescheduler-postsubmits.yaml: |
     job_template: &job_template
       max_concurrency: 10

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -12,6 +12,7 @@ data:
           - pusher/faros
           - pusher/git-store
           - pusher/istio
+          - pusher/k8s-spot-price-monitor
           - pusher/k8s-spot-rescheduler
           - pusher/prom-rule-reloader
           - pusher/testing
@@ -41,6 +42,7 @@ data:
       pusher/faros: *default_plugins
       pusher/git-store: *default_plugins
       pusher/istio: *default_plugins
+      pusher/k8s-spot-price-monitor: *default_plugins
       pusher/k8s-spot-rescheduler: *default_plugins
       pusher/prom-rule-reloader: *default_plugins
       pusher/testing: *default_plugins


### PR DESCRIPTION
Adds a lint and docker-build presubmit as well as a docker-build postsubmit for the https://github.com/pusher/k8s-spot-price-monitor