### PR TITLE
Add image verification and updating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,23 @@ $(GOPATH)/bin/checkconfig:
 	go get k8s.io/test-infra/prow/cmd/checkconfig
 	go install k8s.io/test-infra/prow/cmd/checkconfig
 	@ echo # Produce a new line at the end of each target to help readability
+
+.PHONY:
+check-image-tags:
+	@ $(ECHO) "\033[36;1mChecking image tags\033[0m"
+	scripts/check-image-tags.sh
+	@ echo # Produce a new line at the end of each target to help readability
+
+IMAGE ?= v20190508-da87df0
+.PHONY:
+update-image-tags:
+	@ $(ECHO) "\033[36;1mUpdating image tags\033[0m"
+	scripts/update-image-tags.sh $(IMAGE)
+	@ echo # Produce a new line at the end of each target to help readability
+
+
+.PHONY:
+verify-image-tags: update-image-tags check-image-tags
+	@ $(ECHO) "\033[36mVerifying Git Status\033[0m"
+	@ if [ "$$(git status -s)" != "" ]; then git diff --color; echo "\033[31;1mERROR: Git Diff found. Please run \`make update-image-tags\` and commit the result.\033[0m"; exit 1; else echo "\033[32mAll image tags verified\033[0m";fi
+	@ echo # Produce a new line at the end of each target to help readability

--- a/config/README.md
+++ b/config/README.md
@@ -36,3 +36,41 @@ repositories managed by Prow.
 
 **Note**: All files within this folder and its subfolders must be uniquely named
 due to a limitation in how Prow consumes the configuration files.
+
+## Job Builder Images
+
+Since most jobs should use one of the builder images from the [images](../images)
+folder, the image tag for these images should stay the same, eg:
+
+```
+quay.io/pusher/builder:v20190508-da87df0
+```
+
+Image tags are currently checked in CI and will be enforced to the version in
+the example above.
+
+### Updating the image version
+
+To update the image version, replace the `IMAGE` argument in the root level
+[Makefile](../Makefile) with the desired version.
+
+Then run `make update-image-tags config` from the root of the repository to
+update all jobs using a builder image and update the generated configuration,
+then commit the result.
+
+```bash
+$ sed -i '' -E 's|^IMAGE \?= (.*)|IMAGE \?= <NEW_VERSION>|' Makefile
+$ make update-image-tags config
+$ git add .
+$ git commit -m "Update image tags to <NEW_VERSION>"
+```
+
+## Pinning an image version
+
+If for any reason you need to pin a builder image to a previous build;
+Add a comment after the image tag explaining why the image is pinned and the
+version update enforcement will ignore this line.
+
+```
+quay.io/pusher/builder:pinned # Pinned as an example to disable updater.
+```

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -21,6 +21,27 @@ presubmits:
       trigger: "(?m)^/verify config,?(\\s+|$)"
       rerun_command: "/verify config"
 
+    - name: pull-testing-verify-image-tags
+      max_concurrency: 10
+      path_alias: github.com/pusher/testing
+      agent: kubernetes
+      always_run: true
+      skip_report: false
+      decorate: true
+      spec:
+        containers:
+          - image: quay.io/pusher/kubebuilder-builder:v20190508-da87df0
+            name: verify-image-tags
+            command: ["/usr/local/bin/runner"]
+            args:
+              - make verify-image-tags
+            resources:
+              requests:
+                cpu: 1
+                memory: 1Gi
+      trigger: "(?m)^/verify image-tags,?(\\s+|$)"
+      rerun_command: "/verify image-tags"
+
     - name: pull-testing-build-docker
       max_concurrency: 10
       path_alias: github.com/pusher/testing

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -1138,6 +1138,27 @@ data:
           trigger: "(?m)^/verify config,?(\\s+|$)"
           rerun_command: "/verify config"
 
+        - name: pull-testing-verify-image-tags
+          max_concurrency: 10
+          path_alias: github.com/pusher/testing
+          agent: kubernetes
+          always_run: true
+          skip_report: false
+          decorate: true
+          spec:
+            containers:
+              - image: quay.io/pusher/kubebuilder-builder:v20190508-da87df0
+                name: verify-image-tags
+                command: ["/usr/local/bin/runner"]
+                args:
+                  - make verify-image-tags
+                resources:
+                  requests:
+                    cpu: 1
+                    memory: 1Gi
+          trigger: "(?m)^/verify image-tags,?(\\s+|$)"
+          rerun_command: "/verify image-tags"
+
         - name: pull-testing-build-docker
           max_concurrency: 10
           path_alias: github.com/pusher/testing

--- a/scripts/check-image-tags.sh
+++ b/scripts/check-image-tags.sh
@@ -1,4 +1,4 @@
-#/env/bin/bash
+#!/usr/bin/env bash
 
 RED="\033[31m"
 GREEN="\033[32m"
@@ -12,25 +12,25 @@ failed=false
 image_regex='^(.+)/(.+)/(.+):([a-zA-Z0-9\._-]+)(.*)'
 
 for f in $(ls config/jobs/*/*.yaml); do
-  echo "${CYAN}Processing $f${NC}"
+  echo -e "${CYAN}Processing $f${NC}"
   while read -r image; do
-    image=$(echo $image | sed 's|.*image:||')
-    registry=$(echo $image | sed -E "s|$image_regex|\1|")
-    repository=$(echo $image | sed -E "s|$image_regex|\2/\3|")
-    tag=$(echo $image | sed -E "s|$image_regex|\4|")
-    echo "  Checking tag '$tag' for image '$registry/$repository'..."
+    image=$(echo -e $image | sed 's|.*image:||')
+    registry=$(echo -e $image | sed -E "s|$image_regex|\1|")
+    repository=$(echo -e $image | sed -E "s|$image_regex|\2/\3|")
+    tag=$(echo -e $image | sed -E "s|$image_regex|\4|")
+    echo -e "  Checking tag '$tag' for image '$registry/$repository'..."
     curl --location --fail --silent --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
     "http://$registry/v2/$repository/manifests/$tag" &> /dev/null
     if [ $? != 0 ]; then
-      echo "  ${RED}Tag '$tag' for image '$registry/$repository' not found!${NC}"
+      echo -e "  ${RED}Tag '$tag' for image '$registry/$repository' not found!${NC}"
       failed=true
     else
-      echo "  ${GREEN}Valid tag '$tag' found for image '$registry/$repository'${NC}"
+      echo -e "  ${GREEN}Valid tag '$tag' found for image '$registry/$repository'${NC}"
     fi
   done <<< $(cat $f | grep 'image: ')
 done
 
 if [ "$failed" = true ]; then
-  echo "${RED}Invalid images found.${NC}"
+  echo -e "${RED}Invalid images found.${NC}"
   exit 1
 fi

--- a/scripts/check-image-tags.sh
+++ b/scripts/check-image-tags.sh
@@ -1,0 +1,36 @@
+#/env/bin/bash
+
+RED="\033[31m"
+GREEN="\033[32m"
+CYAN="\033[36;1m"
+NC="\033[0m"
+
+failed=false
+
+# A tag name must be valid ASCII and may contain lowercase and uppercase letters,
+# digits, underscores, periods and dashes.
+image_regex='^(.+)/(.+)/(.+):([a-zA-Z0-9\._-]+)(.*)'
+
+for f in $(ls config/jobs/*/*.yaml); do
+  echo "${CYAN}Processing $f${NC}"
+  while read -r image; do
+    image=$(echo $image | sed 's|.*image:||')
+    registry=$(echo $image | sed -E "s|$image_regex|\1|")
+    repository=$(echo $image | sed -E "s|$image_regex|\2/\3|")
+    tag=$(echo $image | sed -E "s|$image_regex|\4|")
+    echo "  Checking tag '$tag' for image '$registry/$repository'..."
+    curl --location --fail --silent --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    "http://$registry/v2/$repository/manifests/$tag" &> /dev/null
+    if [ $? != 0 ]; then
+      echo "  ${RED}Tag '$tag' for image '$registry/$repository' not found!${NC}"
+      failed=true
+    else
+      echo "  ${GREEN}Valid tag '$tag' found for image '$registry/$repository'${NC}"
+    fi
+  done <<< $(cat $f | grep 'image: ')
+done
+
+if [ "$failed" = true ]; then
+  echo "${RED}Invalid images found.${NC}"
+  exit 1
+fi

--- a/scripts/make-jobs-config.sh
+++ b/scripts/make-jobs-config.sh
@@ -1,4 +1,4 @@
-#/env/bin/bash
+#!/usr/bin/env bash
 
 config=""
 for f in $(ls config/jobs/*/*.yaml); do

--- a/scripts/update-image-tags.sh
+++ b/scripts/update-image-tags.sh
@@ -20,7 +20,7 @@ fi
 
 echo "${CYAN}Updating images to tag '$TAG'${NC}"
 
-for f in $(ls config/jobs/*/*.yaml); do
+for f in $(ls config/jobs/*/*.yaml config/README.md); do
   echo "Updating $f"
   sed -i '' -E "s|$image_regex|quay.io/pusher/\1builder:$TAG|g" $f
   echo "${GREEN}Updated $f${NC}"

--- a/scripts/update-image-tags.sh
+++ b/scripts/update-image-tags.sh
@@ -1,4 +1,4 @@
-#/env/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -16,14 +16,14 @@ pinned_image_regex='quay.io/pusher/(.*)builder:([a-zA-Z0-9\._-]+)\s+(.+)$'
 TAG="${1:-}"
 
 if [[ -z $TAG ]]; then
-  echo "${RED}Must supply desired tag as first argument${NC}"
+  echo -e "${RED}Must supply desired tag as first argument${NC}"
   exit 1
 fi
 
-echo "${CYAN}Updating images to tag '$TAG'${NC}"
+echo -e "${CYAN}Updating images to tag '$TAG'${NC}"
 
 for f in $(ls config/jobs/*/*.yaml config/README.md); do
-  echo "Updating $f"
+  echo -e "Updating $f"
   r="s|$image_regex|quay.io/pusher/\1builder:$TAG|g"
   # Hack to make Linux and Mac sed work in-place
   if [[ $(uname) == "Darwin" ]]; then
@@ -31,11 +31,11 @@ for f in $(ls config/jobs/*/*.yaml config/README.md); do
   else
     sed -E -i $r $f
   fi
-  echo "${GREEN}Updated $f${NC}"
+  echo -e "${GREEN}Updated $f${NC}"
 done
 
 for f in $(ls config/jobs/*/*.yaml); do
   while read -r line; do
-    if [[ ! -z $line ]]; then echo "${YELLOW}[WARNING] Pinned Image in '$f':${NC} ${line#'image: '}"; fi
+    if [[ ! -z $line ]]; then echo -w "${YELLOW}[WARNING] Pinned Image in '$f':${NC} ${line#'image: '}"; fi
   done <<< $(grep -E $pinned_image_regex $f)
 done

--- a/scripts/update-image-tags.sh
+++ b/scripts/update-image-tags.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 
 RED="\033[31m"
 GREEN="\033[32m"
+YELLOW="\033[33;1m"
 CYAN="\033[36;1m"
 NC="\033[0m"
 
 # A tag name must be valid ASCII and may contain lowercase and uppercase letters,
 # digits, underscores, periods and dashes.
 image_regex='quay.io/pusher/(.*)builder:([a-zA-Z0-9\._-]+)$'
+pinned_image_regex='quay.io/pusher/(.*)builder:([a-zA-Z0-9\._-]+)\s+(.+)$'
 
 TAG="${1:-}"
 
@@ -24,4 +26,10 @@ for f in $(ls config/jobs/*/*.yaml config/README.md); do
   echo "Updating $f"
   sed -i '' -E "s|$image_regex|quay.io/pusher/\1builder:$TAG|g" $f
   echo "${GREEN}Updated $f${NC}"
+done
+
+for f in $(ls config/jobs/*/*.yaml); do
+  while read -r line; do
+    if [[ ! -z $line ]]; then echo "${YELLOW}[WARNING] Pinned Image in '$f':${NC} ${line#'image: '}"; fi
+  done <<< $(grep -E $pinned_image_regex $f)
 done

--- a/scripts/update-image-tags.sh
+++ b/scripts/update-image-tags.sh
@@ -1,0 +1,27 @@
+#/env/bin/bash
+
+set -euo pipefail
+
+RED="\033[31m"
+GREEN="\033[32m"
+CYAN="\033[36;1m"
+NC="\033[0m"
+
+# A tag name must be valid ASCII and may contain lowercase and uppercase letters,
+# digits, underscores, periods and dashes.
+image_regex='quay.io/pusher/(.*)builder:([a-zA-Z0-9\._-]+)$'
+
+TAG="${1:-}"
+
+if [[ -z $TAG ]]; then
+  echo "${RED}Must supply desired tag as first argument${NC}"
+  exit 1
+fi
+
+echo "${CYAN}Updating images to tag '$TAG'${NC}"
+
+for f in $(ls config/jobs/*/*.yaml); do
+  echo "Updating $f"
+  sed -i '' -E "s|$image_regex|quay.io/pusher/\1builder:$TAG|g" $f
+  echo "${GREEN}Updated $f${NC}"
+done

--- a/scripts/update-image-tags.sh
+++ b/scripts/update-image-tags.sh
@@ -24,7 +24,13 @@ echo "${CYAN}Updating images to tag '$TAG'${NC}"
 
 for f in $(ls config/jobs/*/*.yaml config/README.md); do
   echo "Updating $f"
-  sed -i '' -E "s|$image_regex|quay.io/pusher/\1builder:$TAG|g" $f
+  r="s|$image_regex|quay.io/pusher/\1builder:$TAG|g"
+  # Hack to make Linux and Mac sed work in-place
+  if [[ $(uname) == "Darwin" ]]; then
+    sed -E -i '' $r $f
+  else
+    sed -E -i $r $f
+  fi
   echo "${GREEN}Updated $f${NC}"
 done
 


### PR DESCRIPTION
This PR adds a make target for `verify-image-tags` that ensures all builder image tags are up to date (bar those that have a comment after them) based on an image defined in the Makefile.

This also ensures that image tags defines in the repo exist on the registry.

Example output for `make update-image-tags` when an image is pinned:

![Screenshot 2019-05-08 at 12 09 01](https://user-images.githubusercontent.com/9232216/57371236-26175680-718a-11e9-8361-8117955c4a88.png)

TODO:
- [x] Remove demo commit
- [x] Document how to update the images
- [x] Document how to pin an image
- [ ] Automate updating the images(?) 