### PR TITLE
Fail fast if environment set up fails

### DIFF
--- a/config/jobs/faros/faros-postsubmits.yaml
+++ b/config/jobs/faros/faros-postsubmits.yaml
@@ -37,7 +37,7 @@ postsubmits:
         containers:
           - <<: *container_template_large
             args:
-              - touch .env && make prepare-env-1.13;
+              - touch .env && make prepare-env-1.13 &&
               - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
               - PUSH_TAGS=${TAGS}
               - make docker-build docker-scan docker-tag docker-push

--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -130,7 +130,7 @@ presubmits:
         containers:
           - <<: *container_template_large
             args:
-              - touch .env; # No config necessary
+              - touch .env && make prepare-env-1.13 &&
               - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
               - PUSH_TAGS=${TAGS}
               - make docker-build docker-scan docker-tag docker-push

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -46,7 +46,7 @@ data:
             containers:
               - <<: *container_template_large
                 args:
-                  - touch .env && make prepare-env-1.13;
+                  - touch .env && make prepare-env-1.13 &&
                   - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
                   - PUSH_TAGS=${TAGS}
                   - make docker-build docker-scan docker-tag docker-push
@@ -185,7 +185,7 @@ data:
             containers:
               - <<: *container_template_large
                 args:
-                  - touch .env; # No config necessary
+                  - touch .env && make prepare-env-1.13 &&
                   - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
                   - PUSH_TAGS=${TAGS}
                   - make docker-build docker-scan docker-tag docker-push


### PR DESCRIPTION
If the environment set up fails, later tasks will fail too, so we should `&&` instead of `;` to make sure we fail fast