### PR TITLE
Add .ssh folder to clonerefs image

### DIFF
--- a/images/clonerefs/Dockerfile
+++ b/images/clonerefs/Dockerfile
@@ -26,3 +26,6 @@ ENV IMAGE=${IMAGE_ARG}
 
 RUN adduser -S -h /home/prow -s /bin/bash -g root -u 1000 prow
 USER prow
+
+# Ensure .ssh folder exists so known_hosts file can be written
+RUN mkdir -p /home/prow/.ssh


### PR DESCRIPTION
Make the `/home/prow/.ssh` folder ahead of time, it is required by the clonerefs process if using SSH to clone repositories