### PR TITLE
Fix indentation of label selector for preset-service-account

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,7 +40,7 @@ log_level: info
 
 presets:
   - labels:
-    preset-service-account: "true"
+      preset-service-account: "true"
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -49,7 +49,7 @@ data:
 
     presets:
       - labels:
-        preset-service-account: "true"
+          preset-service-account: "true"
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/service-account/service-account.json


### PR DESCRIPTION
I had wondered why this preset was being applied to all jobs 🤦‍♂ 

This should fix the label selector and since nothing actually uses these credentials, this should be fine to merge.

It was never intended to be applied to every job.