### PR TITLE
Add admin-builder image

### DIFF
--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -58,7 +58,9 @@ presubmits:
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:
-              - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA} make --directory=images push
+              - VERSION=pull-${PULL_NUMBER}
+              - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
+              - make --directory=images push
             resources:
               requests:
                 cpu: 1

--- a/images/Makefile
+++ b/images/Makefile
@@ -23,11 +23,11 @@ all: build
 #
 ####
 
-build: builder golang-builder kubebuilder-builder clonerefs python-builder
+build: builder golang-builder kubebuilder-builder clonerefs python-builder admin-builder
 
-tag: docker-tag-builder docker-tag-golang-builder docker-tag-kubebuilder-builder docker-tag-clonerefs docker-tag-python-builder
+tag: docker-tag-builder docker-tag-golang-builder docker-tag-kubebuilder-builder docker-tag-clonerefs docker-tag-python-builder docker-tag-admin-builder
 
-push: docker-push-builder docker-push-golang-builder docker-push-kubebuilder-builder docker-push-clonerefs docker-push-python-builder
+push: docker-push-builder docker-push-golang-builder docker-push-kubebuilder-builder docker-push-clonerefs docker-push-python-builder docker-push-admin-builder
 
 ####
 #
@@ -42,6 +42,8 @@ golang-builder: builder docker-build-golang-builder
 kubebuilder-builder: golang-builder docker-build-kubebuilder-builder
 
 python-builder: builder docker-build-python-builder
+
+admin-builder: python-builder docker-build-admin-builder
 
 clonerefs: docker-build-clonerefs
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -54,7 +54,10 @@ clonerefs: docker-build-clonerefs
 ###
 
 docker-build-%:
-	docker build --build-arg IMAGE_ARG=$(REPO)/$*:$(VERSION) --build-arg VERSION=$(VERSION) -t $(REPO)/$*:$(VERSION) $*
+	# Use `-` to ignore the exit code from the pull below.
+	# If we can't pull we just have no cache to start from.
+	- docker pull $(REPO)/$*:$(VERSION)
+	docker build --build-arg IMAGE_ARG=$(REPO)/$*:$(VERSION) --build-arg VERSION=$(VERSION) --cache-from $(REPO)/$*:$(VERSION) -t $(REPO)/$*:$(VERSION) $*
 	@echo "\033[36mBuilt $(REPO)/$*:$(VERSION)\033[0m"
 
 TAGS ?= ${VERSION},latest

--- a/images/admin-builder/Dockerfile
+++ b/images/admin-builder/Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2019 Pusher Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#############################################################################
+###
+### ADMIN BUILDER - From quay.io/pusher/builder with Kubectl, AWS and GCLOUD
+###                 CLIs
+###
+#############################################################################
+
+ARG VERSION=latest
+FROM quay.io/pusher/python-builder:${VERSION}
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+# Switch to root user to perform installation
+USER root
+
+# Install Kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+		&& chmod +x ./kubectl \
+		&& mv ./kubectl /usr/local/bin/kubectl
+
+# Install AWS CLI & check it was installed
+RUN pip3 install awscli --upgrade \
+    && aws --version
+
+# Install GCLOUD CLI & check it was installed
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-250.0.0-linux-x86_64.tar.gz \
+    && tar -zxvf google-cloud-sdk-250.0.0-linux-x86_64.tar.gz google-cloud-sdk \
+		&& google-cloud-sdk/install.sh
+ENV PATH=/workspace/google-cloud-sdk/bin:${PATH}
+RUN gcloud --version
+
+# Switch back to prow user for publish
+USER prow

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -1175,7 +1175,9 @@ data:
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
-                  - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA} make --directory=images push
+                  - VERSION=pull-${PULL_NUMBER}
+                  - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
+                  - make --directory=images push
                 resources:
                   requests:
                     cpu: 1


### PR DESCRIPTION
We have a number of steps in jobs that require kubectl but the only image currently containing it is the `admin-builder` image which has a lot of other stuff in it too, this should be a slightly slimmer image.

It also contains the AWS and GCloud CLIs