### PR TITLE
Improve rollout logic for Prow components

### DIFF
--- a/prow/deck/deployment.yaml
+++ b/prow/deck/deployment.yaml
@@ -11,8 +11,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxSurge: 2
+      maxUnavailable: 0
+  minReadySeconds: 10
   template:
     metadata:
       labels:

--- a/prow/hook/deployment.yaml
+++ b/prow/hook/deployment.yaml
@@ -11,8 +11,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxSurge: 2
+      maxUnavailable: 0
+  minReadySeconds: 10
   template:
     metadata:
       labels:

--- a/prow/needs-rebase/deployment.yaml
+++ b/prow/needs-rebase/deployment.yaml
@@ -11,8 +11,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxSurge: 2
+      maxUnavailable: 0
+  minReadySeconds: 10
   template:
     metadata:
       labels:


### PR DESCRIPTION
We keep getting 502s from the UI as we rollout updates for approx 30 seconds or so. The rollout of new pods could be smoother, this aims to fix that by making sure we only take down old pods once the new pods have been ready for approx 10 seconds