### PR TITLE
Fix colour output of scripts on prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,20 +29,20 @@ $(GOPATH)/bin/checkconfig:
 
 .PHONY:
 check-image-tags:
-	@ $(ECHO) "\033[36;1mChecking image tags\033[0m"
+	@ $(ECHO) "\033[36m\033[1mChecking image tags\033[0m"
 	scripts/check-image-tags.sh
 	@ echo # Produce a new line at the end of each target to help readability
 
 TAG ?= v20190508-da87df0
 .PHONY:
 update-image-tags:
-	@ $(ECHO) "\033[36;1mUpdating image tags\033[0m"
+	@ $(ECHO) "\033[36m\033[1mUpdating image tags\033[0m"
 	scripts/update-image-tags.sh $(TAG)
 	@ echo # Produce a new line at the end of each target to help readability
 
 
 .PHONY:
 verify-image-tags: update-image-tags check-image-tags
-	@ $(ECHO) "\033[36mVerifying Git Status\033[0m"
-	@ if [ "$$(git status -s)" != "" ]; then git diff --color; echo "\033[31;1mERROR: Git Diff found. Please run \`make update-image-tags\` and commit the result.\033[0m"; exit 1; else echo "\033[32mAll image tags verified\033[0m";fi
+	@ $(ECHO) "\033[36m\033[1mVerifying Git Status\033[0m"
+	@ if [ "$$(git status -s)" != "" ]; then git diff --color; echo "\033[31m\033[1mERROR: Git Diff found. Please run \`make update-image-tags\` and commit the result.\033[0m"; exit 1; else echo "\033[32mAll image tags verified\033[0m";fi
 	@ echo # Produce a new line at the end of each target to help readability

--- a/scripts/check-image-tags.sh
+++ b/scripts/check-image-tags.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
+BOLD="\033[1m"
 RED="\033[31m"
 GREEN="\033[32m"
-CYAN="\033[36;1m"
+CYAN="\033[36m"
 NC="\033[0m"
 
 failed=false
@@ -12,7 +13,7 @@ failed=false
 image_regex='^(.+)/(.+)/(.+):([a-zA-Z0-9\._-]+)(.*)'
 
 for f in $(ls config/jobs/*/*.yaml); do
-  echo -e "${CYAN}Processing $f${NC}"
+  echo -e "${CYAN}${BOLD}Processing $f${NC}"
   while read -r image; do
     image=$(echo -e $image | sed 's|.*image:||')
     registry=$(echo -e $image | sed -E "s|$image_regex|\1|")

--- a/scripts/update-image-tags.sh
+++ b/scripts/update-image-tags.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
+BOLD="\033[1m"
 RED="\033[31m"
 GREEN="\033[32m"
-YELLOW="\033[33;1m"
-CYAN="\033[36;1m"
+YELLOW="\033[33m"
+CYAN="\033[36m"
 NC="\033[0m"
 
 # A tag name must be valid ASCII and may contain lowercase and uppercase letters,
@@ -20,7 +21,7 @@ if [[ -z $TAG ]]; then
   exit 1
 fi
 
-echo -e "${CYAN}Updating images to tag '$TAG'${NC}"
+echo -e "${CYAN}${BOLD}Updating images to tag '$TAG'${NC}"
 
 for f in $(ls config/jobs/*/*.yaml config/README.md); do
   echo -e "Updating $f"
@@ -36,6 +37,6 @@ done
 
 for f in $(ls config/jobs/*/*.yaml); do
   while read -r line; do
-    if [[ ! -z $line ]]; then echo -e "${YELLOW}[WARNING] Pinned Image in '$f':${NC} ${line#'image: '}"; fi
+    if [[ ! -z $line ]]; then echo -e "${YELLOW}${BOLD}[WARNING] Pinned Image in '$f':${NC} ${line#'image: '}"; fi
   done <<< $(grep -E $pinned_image_regex $f)
 done


### PR DESCRIPTION
Some colours are not output correctly when viewing the logs in prow, I think this might fix that by separating the bold combinations.

I just wanted to see how to make it work so that I could document it as a way to do it in the docs, but hey, may as, PR too