### PR TITLE
Add all target to set default for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ECHO := echo
 
+all: verify-config verify-image-tags
+
 .PHONY: config
 config:
 	@ $(ECHO) "\033[36mGenerating Config\033[0m"


### PR DESCRIPTION
This is so you can run make and have everything verified before you push.