### PR TITLE
Add more linting tools to golang-builder

### DIFF
--- a/images/golang-builder/Dockerfile
+++ b/images/golang-builder/Dockerfile
@@ -79,6 +79,16 @@ RUN go get github.com/go-delve/delve/cmd/dlv
 # Install dep for dependencies
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 # Install golangci-lint for linting
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
 # Install ginkgo for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
+
+# Install more lint and code generation tools
+RUN go get golang.org/x/tools/cmd/goimports \
+    && go get github.com/kisielk/errcheck \
+    && go get github.com/gordonklaus/ineffassign \
+    && go get github.com/fzipp/gocyclo \
+    && go get honnef.co/go/tools/... \
+    && go get golang.org/x/lint/golint \
+    && go get gopkg.in/golang/mock.v1/gomock \
+    && go get gopkg.in/golang/mock.v1/mockgen

--- a/images/golang-builder/Dockerfile
+++ b/images/golang-builder/Dockerfile
@@ -79,7 +79,7 @@ RUN go get github.com/go-delve/delve/cmd/dlv
 # Install dep for dependencies
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 # Install golangci-lint for linting
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
 # Install ginkgo for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
 


### PR DESCRIPTION
This adds a bunch more tools and linters to the golang-builder image that I have seen being used in our projects.

Also updates golangci-lint to 1.17.1