### PR TITLE
 Enable GitHub reporter to report status checks for PostSubmits

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,11 @@ prowjob_namespace: default
 pod_namespace: default
 log_level: info
 
+github_reporter:
+  job_types_to_report:
+  - presubmit
+  - postsubmit
+
 presets:
   - labels:
       preset-service-account: "true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -47,6 +47,11 @@ data:
     pod_namespace: default
     log_level: info
 
+    github_reporter:
+      job_types_to_report:
+      - presubmit
+      - postsubmit
+
     presets:
       - labels:
           preset-service-account: "true"


### PR DESCRIPTION
This enables green ticks/red crosses for commits when PostSubmit jobs run against them