### PR TITLE
[IS-326] Add Go wrapper to generate JUnit from go test output

### DIFF
--- a/images/builder/runner
+++ b/images/builder/runner
@@ -101,6 +101,12 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && which gcloud &> /dev/null; 
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
 fi
 
+export GOLANG_JUNIT=${GOLANG_JUNIT:-false}
+if [[ "${GOLANG_JUNIT}" == "true" ]]; then
+  export PATH=/home/prow/.local/go/bin:${PATH}
+  export GO_WRAPPER_JUNIT_PATH=${ARTIFACTS}/junit.xml
+fi
+
 # Use a reproducible build date based on the most recent git commit timestamp.
 SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
 export SOURCE_DATE_EPOCH

--- a/images/golang-builder/Dockerfile
+++ b/images/golang-builder/Dockerfile
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG VERSION=latest
+
+#######################################################################
+###
+### GOLANG Pre-BUILDER - For building any go binaries needed in later steps
+###
+#######################################################################
+
+FROM golang:1.12 AS builder
+COPY wrapper/* $GOPATH/src/wrapper/
+
+ENV GO111MODULE=on
+WORKDIR $GOPATH/src/wrapper
+RUN go build -o /wrapper $GOPATH/src/wrapper
+
+
 #############################################################################
 ###
 ### GOLANG BUILDER - From quay.io/pusher/builder with Go tooling for building
@@ -19,7 +35,6 @@
 ###
 #############################################################################
 
-ARG VERSION=latest
 FROM quay.io/pusher/builder:${VERSION}
 
 # add env we can debug with the image name:tag
@@ -92,3 +107,6 @@ RUN go get golang.org/x/tools/cmd/goimports \
     && go get golang.org/x/lint/golint \
     && go get gopkg.in/golang/mock.v1/gomock \
     && go get gopkg.in/golang/mock.v1/mockgen
+
+# Copy the go wrapper to /home/prow/.local/bin/go/
+COPY --from=builder /wrapper /home/prow/.local/go/bin/go

--- a/images/golang-builder/wrapper/go.mod
+++ b/images/golang-builder/wrapper/go.mod
@@ -1,0 +1,5 @@
+module wrapper
+
+go 1.12
+
+require github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024

--- a/images/golang-builder/wrapper/go.sum
+++ b/images/golang-builder/wrapper/go.sum
@@ -1,0 +1,2 @@
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/images/golang-builder/wrapper/main.go
+++ b/images/golang-builder/wrapper/main.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/jstemmer/go-junit-report/formatter"
+	"github.com/jstemmer/go-junit-report/parser"
+)
+
+func main() {
+	// First argument is the executable, don't need that
+	args := os.Args[1:]
+	realGo := getEnv("GO_WRAPPER_REAL_GO", "/usr/local/go/bin/go")
+	junitPath := getEnv("GO_WRAPPER_JUNIT_PATH", "")
+	debugEnv := getEnv("GO_WRAPPER_DEBUG", "false")
+	debug, err := strconv.ParseBool(debugEnv)
+	if err != nil {
+		log.Printf("Expected GO_WRAPPER_DEBUG to be bool, got %s: %v", debugEnv, err)
+	}
+
+	// If not requesting Junit, don't bother streaming the output
+	if junitPath == "" || len(args) < 1 || args[0] != "test" {
+		if debug {
+			log.Printf("Running without JUnit output: go %v", args)
+		}
+		runWithoutJunit(realGo, args...)
+		return
+	}
+
+	if debug {
+		log.Printf("Running with JUnit output: go %v", args)
+	}
+
+	// JunitPath should be set
+	// First argument should be test, no need to pass first argument
+	runWithJunit(realGo, junitPath, args[1:]...)
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func runWithoutJunit(realGo string, args ...string) {
+	// Run the actual go process with the args input
+	cmd := exec.Command(realGo, args...)
+
+	// Attach Stdout, Stderr and Stdin as normal
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	// Execute the command
+	err := cmd.Run()
+
+	// If theres an error, exit with the correct code if possible
+	if err != nil {
+		log.Printf("Error executing command: %v", err)
+		exitError, ok := err.(*exec.ExitError)
+		if !ok {
+			os.Exit(1)
+		} else {
+			os.Exit(exitError.ExitCode())
+		}
+	}
+
+	// No error so exit 0
+	os.Exit(0)
+}
+
+func runWithJunit(realGo, junitPath string, args ...string) {
+	// Make sure we have verbose test output
+	if contains(args, "-v") {
+		args = append([]string{"test"}, args...)
+	} else {
+		args = append([]string{"test", "-v"}, args...)
+	}
+
+	// Run the actual go process with the args input
+	cmd := exec.Command(realGo, args...)
+
+	// Attach Stdout, Stderr and Stdin, copying Stderr and Stdout to the buffer
+	junitBuffer := bytes.NewBuffer([]byte{})
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = &writerCopier{out: os.Stdout, copy: junitBuffer}
+	cmd.Stderr = &writerCopier{out: os.Stderr, copy: junitBuffer}
+
+	// Execute the command
+	err := cmd.Run()
+
+	// If theres an error, exit with the correct code if possible
+	if err != nil {
+		log.Printf("Error executing command: %v", err)
+		exitError, ok := err.(*exec.ExitError)
+		if !ok {
+			os.Exit(1)
+		} else {
+			os.Exit(exitError.ExitCode())
+		}
+	}
+
+	// Parse the go test result into a report
+	report, err := parser.Parse(junitBuffer, "")
+	if err != nil {
+		log.Printf("Error parsing go test output: %v", err)
+		os.Exit(1)
+	}
+
+	outFile, err := os.Create(junitPath)
+	if err != nil {
+		log.Printf("Error opening file %s: %v", junitPath, err)
+		os.Exit(1)
+	}
+	defer outFile.Close()
+
+	// Write the report to the output file
+	err = formatter.JUnitReportXML(report, false, "", outFile)
+	if err != nil {
+		fmt.Printf("Error writing XML: %s\n", err)
+		os.Exit(1)
+	}
+
+	// No error so exit 0
+	os.Exit(0)
+}
+
+type writerCopier struct {
+	out  io.Writer
+	copy io.Writer
+}
+
+func (w *writerCopier) Write(p []byte) (int, error) {
+	// Write to the main output
+	n, err := w.out.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	// Write to the copy
+	n, err = w.copy.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
If `GOLANG_JUNIT=true` within a job, the `runner` sets the `PATH` to have `/home/prow/.local/go/bin/` as a prefix. This means the binary within this, called `go`, will be selected before the real `go` binary at `/usr/local/bin/go`.

This fake `go` binary is a wrapper that checks if you are `go test`ing, and intercepts the output to generate a JUnit file placed at `$ARTIFACTS/junit.xml`.

The `$ARTIFACTS` directory in a ProwJob is automatically uploaded to GCS, and the Prow JUnit viewer looks for any files matching `junit.*\.xml`, so will read this generated file.

By adding a Preset to the configuration, users will be able to opt-in to generate JUnit files when running their tests.