### PR TITLE
 Simplify Python builder image

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -43,7 +43,7 @@ kubebuilder-builder: golang-builder docker-build-kubebuilder-builder
 
 python-builder: builder docker-build-python-builder
 
-admin-builder: python-builder docker-build-admin-builder
+admin-builder: builder docker-build-admin-builder
 
 clonerefs: docker-build-clonerefs
 

--- a/images/admin-builder/Dockerfile
+++ b/images/admin-builder/Dockerfile
@@ -20,7 +20,7 @@
 #############################################################################
 
 ARG VERSION=latest
-FROM quay.io/pusher/python-builder:${VERSION}
+FROM quay.io/pusher/builder:${VERSION}
 
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -58,6 +58,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     pkg-config \
     procps \
+    python \
+    python3 \
+    python-pip \
+    python3-pip \
     rsync \
     unzip \
     wget \

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -62,6 +62,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python-pip \
     python3-pip \
+    python-setuptools \
+    python3-setuptools \
     rsync \
     unzip \
     wget \

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -46,6 +46,9 @@ ENV WORKSPACE=/workspace \
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
+# Add the testing repository so we can get newer Python versions (> 3.5)
+RUN echo 'deb http://ftp.de.debian.org/debian testing main' >> /etc/apt/sources.list
+
 # common util tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/images/python-builder/Dockerfile
+++ b/images/python-builder/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update && apt-get install -y \
 		python3 \
 		python-pip \
 		python3-pip \
+		python-setuptools \
+		python3-setuptools \
 	&& rm -rf /var/lib/apt/lists/*
 
 #####################################
@@ -50,7 +52,7 @@ RUN apt-get update && apt-get install -y \
 #####################################
 
 # Tools for linting
-RUN pip install setuptools flake8 pylint
+RUN pip install flake8 pylint
 RUN pip3 install flake8 pylint
 
 

--- a/images/python-builder/Dockerfile
+++ b/images/python-builder/Dockerfile
@@ -50,7 +50,8 @@ RUN apt-get update && apt-get install -y \
 #####################################
 
 # Tools for linting
-RUN pip install flake8 pylint
+RUN pip install setuptools flake8 pylint
+RUN pip3 install flake8 pylint
 
 
 # Switch back to prow user for publish

--- a/images/python-builder/Dockerfile
+++ b/images/python-builder/Dockerfile
@@ -35,133 +35,13 @@ USER root
 ###
 #################
 
-# ensure local python is preferred over distribution python
-ENV PATH /usr/local/bin:$PATH
-
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
-
-# Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		autoconf \
-		automake \
-		bzip2 \
-		dirmngr \
-		dpkg-dev \
-		file \
-		g++ \
-		gcc \
-		imagemagick \
-		libbz2-dev \
-		libc6-dev \
-		libcurl4-openssl-dev \
-		libdb-dev \
-		libevent-dev \
-		libffi-dev \
-		libgdbm-dev \
-		libgeoip-dev \
-		libglib2.0-dev \
-		libgmp-dev \
-		libjpeg-dev \
-		libkrb5-dev \
-		liblzma-dev \
-		libmagickcore-dev \
-		libmagickwand-dev \
-		libncurses5-dev \
-		libncursesw5-dev \
-		libpng-dev \
-		libpq-dev \
-		libreadline-dev \
-		libsqlite3-dev \
-		libssl-dev \
-		libtool \
-		libwebp-dev \
-		libxml2-dev \
-		libxslt-dev \
-		libyaml-dev \
-		make \
-		patch \
-		unzip \
-		xz-utils \
-		zlib1g-dev \
-		tk-dev \
-		uuid-dev \
+# Install Python
+RUN apt-get update && apt-get install -y \
+		python \
+		python3 \
+		python-pip \
+		python3-pip \
 	&& rm -rf /var/lib/apt/lists/*
-
-ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.7.3
-
-RUN set -ex \
-	\
-	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& for server in ha.pool.sks-keyservers.net \
-              hkp://p80.pool.sks-keyservers.net:80 \
-              keyserver.ubuntu.com \
-              hkp://keyserver.ubuntu.com:80 \
-              pgp.mit.edu; do \
-    			gpg --keyserver "$server" --recv-keys "$GPG_KEY" && break || echo "Trying new server..."; \
-		 done \
-	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
-	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
-	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
-	&& mkdir -p /usr/src/python \
-	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-	&& rm python.tar.xz \
-	\
-	&& cd /usr/src/python \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--enable-loadable-sqlite-extensions \
-		--enable-shared \
-		--with-system-expat \
-		--with-system-ffi \
-		--without-ensurepip \
-	&& make -j "$(nproc)" \
-	&& make install \
-	&& ldconfig \
-	\
-	&& find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' + \
-	&& rm -rf /usr/src/python \
-	\
-	&& python3 --version
-
-# make some useful symlinks that are expected to exist
-RUN cd /usr/local/bin \
-	&& ln -s idle3 idle \
-	&& ln -s pydoc3 pydoc \
-	&& ln -s python3 python \
-	&& ln -s python3-config python-config
-
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.1
-
-RUN set -ex; \
-	\
-	wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-	\
-	python get-pip.py \
-		--disable-pip-version-check \
-		--no-cache-dir \
-		"pip==$PYTHON_PIP_VERSION" \
-	; \
-	pip --version; \
-	\
-	find /usr/local -depth \
-		\( \
-			\( -type d -a \( -name test -o -name tests \) \) \
-			-o \
-			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-		\) -exec rm -rf '{}' +; \
-	rm -f get-pip.py
 
 #####################################
 ###


### PR DESCRIPTION
The python builder image was really complex, perhaps it would be simpler to just use apt to install it

This also makes sure the root builder image has Pip installed so that other images can install python tooling

And finally, the admin-builder image doesn't need to spawn off of the python builder image so this should make it smaller