### PR TITLE
Make sure to run `./configure` before building Docker image

### DIFF
--- a/config/jobs/quack/quack-postsubmits.yaml
+++ b/config/jobs/quack/quack-postsubmits.yaml
@@ -36,9 +36,8 @@ postsubmits:
         containers:
           - <<: *container_template_large
             args:
-              - touch .env; # No config necessary
               - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
               - PUSH_TAGS=${TAGS}
-              - touch .env && make docker-build docker-tag docker-push
+              - ./configure && make docker-build docker-tag docker-push
             securityContext:
               privileged: true

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -1126,10 +1126,9 @@ data:
             containers:
               - <<: *container_template_large
                 args:
-                  - touch .env; # No config necessary
                   - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
                   - PUSH_TAGS=${TAGS}
-                  - touch .env && make docker-build docker-tag docker-push
+                  - ./configure && make docker-build docker-tag docker-push
                 securityContext:
                   privileged: true
   quack_quack-presubmits.yaml: |


### PR DESCRIPTION
As the `docker-build` task depends on linting and tests passing.