### PR TITLE
Force SSH cloning of private repositories from GitHub

### DIFF
--- a/images/builder/runner
+++ b/images/builder/runner
@@ -89,6 +89,8 @@ export GITHUB_SSH_KEYSCAN=${GITHUB_SSH_KEYSCAN:-false}
 if [[ "${GITHUB_SSH_KEYSCAN}" == "true" ]]; then
   mkdir -p ~/.ssh
   ssh-keyscan github.com >> ~/.ssh/known_hosts
+  # Force use of SSH cloning from GitHub
+  git config --global url."git@github.com:".insteadOf "https://github.com/"
 fi
 
 # disable error exit so we can run post-command cleanup


### PR DESCRIPTION
This forces Git to use SSH if you have provided an SSH key for cloning from GitHub. This is required for authentication for private github repositories