### PR TITLE
Install Docker-Compose in builder images

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -118,6 +118,9 @@ COPY --from=builder ["/barnacle", "/usr/local/bin/"]
 # add ecr login help
 COPY --from=builder ["/go/bin/docker-credential-ecr-login", "/usr/local/bin/"]
 
+# Install docker-compose
+RUN pip install docker-compose
+
 #
 # END: DOCKER IN DOCKER SETUP
 #

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -119,7 +119,7 @@ COPY --from=builder ["/barnacle", "/usr/local/bin/"]
 COPY --from=builder ["/go/bin/docker-credential-ecr-login", "/usr/local/bin/"]
 
 # Install docker-compose
-RUN pip install docker-compose
+RUN pip install 'docker-compose>=1.24.0,<1.25.0'
 
 #
 # END: DOCKER IN DOCKER SETUP


### PR DESCRIPTION
This will add Docker-Compose to all builder images so that test suites that require it for bringing up supporting containers should have it on hand