### PR TITLE
Upgrade Prow deployments to apps/v1 and fix autoscaling

### DIFF
--- a/prow/deck/deployment.yaml
+++ b/prow/deck/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -8,12 +8,15 @@ metadata:
   annotations:
     wave.pusher.com/update-on-config-change: "true"
 spec:
+  minReadySeconds: 10
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
-  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app: deck
   template:
     metadata:
       labels:
@@ -21,6 +24,27 @@ spec:
     spec:
       serviceAccountName: "deck"
       terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - deck
+              topologyKey: kubernetes.io/hostname
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - deck
+              topologyKey: failure-domain.beta.kubernetes.io/zone
       containers:
         - name: deck
           image: gcr.io/k8s-prow/deck:v20190615-f3db6c682
@@ -33,6 +57,10 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
           volumeMounts:
             - name: config
               mountPath: /etc/config
@@ -46,19 +74,19 @@ spec:
             - name: gcs-credentials
               mountPath: /etc/gcs-credentials
               readOnly: true
-      livenessProbe:
-        httpGet:
-          path: /healthz
-          port: 8081
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      readinessProbe:
-        httpGet:
-          path: /healthz/ready
-          port: 8081
-        initialDelaySeconds: 10
-        periodSeconds: 3
-        timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            timeoutSeconds: 3
       volumes:
         - name: config
           configMap:

--- a/prow/hook/deployment.yaml
+++ b/prow/hook/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -8,12 +8,15 @@ metadata:
   annotations:
     wave.pusher.com/update-on-config-change: "true"
 spec:
+  minReadySeconds: 10
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
-  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app: hook
   template:
     metadata:
       labels:
@@ -21,6 +24,27 @@ spec:
     spec:
       serviceAccountName: "hook"
       terminationGracePeriodSeconds: 180
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - hook
+              topologyKey: kubernetes.io/hostname
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - hook
+              topologyKey: failure-domain.beta.kubernetes.io/zone
       containers:
       - name: hook
         image: gcr.io/k8s-prow/hook:v20190615-f3db6c682
@@ -31,6 +55,10 @@ spec:
         ports:
           - name: http
             containerPort: 8888
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 100m
         volumeMounts:
         - name: hmac
           mountPath: /etc/webhook
@@ -47,19 +75,19 @@ spec:
         - name: jobs
           mountPath: /etc/jobs
           readOnly: true
-      livenessProbe:
-        httpGet:
-          path: /healthz
-          port: 8081
-        initialDelaySeconds: 3
-        periodSeconds: 3
-      readinessProbe:
-        httpGet:
-          path: /healthz/ready
-          port: 8081
-        initialDelaySeconds: 10
-        periodSeconds: 3
-        timeoutSeconds: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
+          timeoutSeconds: 3
       volumes:
       - name: hmac
         secret:

--- a/prow/horologium/deployment.yaml
+++ b/prow/horologium/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -11,6 +11,9 @@ spec:
   replicas: 1 # Do not scale up.
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: horologium
   template:
     metadata:
       labels:

--- a/prow/needs-rebase/deployment.yaml
+++ b/prow/needs-rebase/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -8,18 +8,42 @@ metadata:
   annotations:
     wave.pusher.com/update-on-config-change: "true"
 spec:
+  minReadySeconds: 10
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
-  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app: needs-rebase
   template:
     metadata:
       labels:
         app: needs-rebase
     spec:
       terminationGracePeriodSeconds: 180
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - needs-rebase
+              topologyKey: kubernetes.io/hostname
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - needs-rebase
+              topologyKey: failure-domain.beta.kubernetes.io/zone
       containers:
       - name: needs-rebase
         image: gcr.io/k8s-prow/needs-rebase:v20190615-f3db6c682
@@ -29,6 +53,10 @@ spec:
         ports:
           - name: http
             containerPort: 8888
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 100m
         volumeMounts:
         - name: hmac
           mountPath: /etc/webhook

--- a/prow/plank/deployment.yaml
+++ b/prow/plank/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -11,6 +11,9 @@ spec:
   replicas: 1 # Do not scale up.
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: plank
   template:
     metadata:
       labels:

--- a/prow/sinker/deployment.yaml
+++ b/prow/sinker/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -9,6 +9,9 @@ metadata:
     wave.pusher.com/update-on-config-change: "true"  
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: sinker
   template:
     metadata:
       labels:

--- a/prow/tide/deployment.yaml
+++ b/prow/tide/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -11,6 +11,9 @@ spec:
   replicas: 1 # Do not scale up.
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: tide
   template:
     metadata:
       labels:


### PR DESCRIPTION
This upgrades all of the Prow deployment yamls to apps/v1 and ensures that the autoscaling can work correctly (now resources are requested for those that autoscale)