### PR TITLE
Wait for network before executing clonerefs

### DIFF
--- a/images/clonerefs/Dockerfile
+++ b/images/clonerefs/Dockerfile
@@ -24,5 +24,9 @@ FROM gcr.io/k8s-prow/clonerefs:v20190615-f3db6c682
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
+RUN mv /clonerefs /prow-clonerefs
+COPY clonerefs /clonerefs
+RUN chmod +x /clonerefs
+
 RUN adduser -S -h /home/prow -s /bin/bash -g root -u 1000 prow
 USER prow

--- a/images/clonerefs/clonerefs
+++ b/images/clonerefs/clonerefs
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+until ping -c1 google.com > /dev/null 2>&1
+do
+  echo "Waiting for network..."
+  sleep 1
+done
+
+/prow-clonerefs


### PR DESCRIPTION
We have had some issues with clonerefs failing to checkout repos, we suspect this is because the network is not yet up. 

This adds a script in front of the clonerefs process that checks network is up before cloning the repo, it will hopefully fix this issue