### PR TITLE
Revert clonerefs to previous known working version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,7 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "quay.io/pusher/clonerefs:v20190716-842415b"
+      clonerefs: "quay.io/pusher/clonerefs:v20190401-6a7e3ff"
       initupload: "gcr.io/k8s-prow/initupload:v20190615-f3db6c682"
       entrypoint: "gcr.io/k8s-prow/entrypoint:v20190615-f3db6c682"
       sidecar: "gcr.io/k8s-prow/sidecar:v20190615-f3db6c682"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17,7 +17,7 @@ data:
         timeout: 7200000000000 # 2h
         grace_period: 15000000000 # 15s
         utility_images:
-          clonerefs: "quay.io/pusher/clonerefs:v20190716-842415b"
+          clonerefs: "quay.io/pusher/clonerefs:v20190401-6a7e3ff"
           initupload: "gcr.io/k8s-prow/initupload:v20190615-f3db6c682"
           entrypoint: "gcr.io/k8s-prow/entrypoint:v20190615-f3db6c682"
           sidecar: "gcr.io/k8s-prow/sidecar:v20190615-f3db6c682"


### PR DESCRIPTION
I had tested this new image with our private instance of Prow which runs clonerefs as root, this instance on the other hand runs as a non-root user which does not have the ability to ping

Reverting while I think up a new solution