### PR TITLE
 Update Builder images to v20190729-d71ced0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ check-image-tags:
 	scripts/check-image-tags.sh
 	@ echo # Produce a new line at the end of each target to help readability
 
-TAG ?= v20190716-842415b
+TAG ?= v20190729-d71ced0
 .PHONY:
 update-image-tags:
 	@ $(ECHO) "\033[36m\033[1mUpdating image tags\033[0m"

--- a/config/README.md
+++ b/config/README.md
@@ -44,7 +44,7 @@ Since most jobs should use one of the builder images from the [images](../images
 folder, the image tag for these images should stay the same, eg:
 
 ```
-quay.io/pusher/builder:v20190716-842415b
+quay.io/pusher/builder:v20190729-d71ced0
 ```
 
 Image tags are currently checked in CI and will be enforced to the version in

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,7 @@ plank:
     timeout: 7200000000000 # 2h
     grace_period: 15000000000 # 15s
     utility_images:
-      clonerefs: "quay.io/pusher/clonerefs:v20190401-6a7e3ff"
+      clonerefs: "quay.io/pusher/clonerefs:v20190729-d71ced0"
       initupload: "gcr.io/k8s-prow/initupload:v20190615-f3db6c682"
       entrypoint: "gcr.io/k8s-prow/entrypoint:v20190615-f3db6c682"
       sidecar: "gcr.io/k8s-prow/sidecar:v20190615-f3db6c682"

--- a/config/jobs/faros/faros-postsubmits.yaml
+++ b/config/jobs/faros/faros-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+  image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+  image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/git-store/git-store-presubmits.yaml
+++ b/config/jobs/git-store/git-store-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190716-842415b
+  image: quay.io/pusher/python-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190716-842415b
+  image: quay.io/pusher/python-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-presubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-postsubmits.yaml
+++ b/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190716-842415b
+  image: quay.io/pusher/python-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-presubmits.yaml
+++ b/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190716-842415b
+  image: quay.io/pusher/python-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/prom-rule-reloader/prom-rule-reloader-postsubmits.yaml
+++ b/config/jobs/prom-rule-reloader/prom-rule-reloader-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/prom-rule-reloader/prom-rule-reloader-presubmits.yaml
+++ b/config/jobs/prom-rule-reloader/prom-rule-reloader-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/quack/quack-postsubmits.yaml
+++ b/config/jobs/quack/quack-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/quack/quack-presubmits.yaml
+++ b/config/jobs/quack/quack-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190716-842415b
+  image: quay.io/pusher/golang-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/testing/testing-postsubmits.yaml
+++ b/config/jobs/testing/testing-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
         preset-quay-credentials: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:v20190716-842415b
+          - image: quay.io/pusher/builder:v20190729-d71ced0
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+          - image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
             name: verify-config
             command: ["/usr/local/bin/runner"]
             args:
@@ -30,7 +30,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+          - image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
             name: verify-image-tags
             command: ["/usr/local/bin/runner"]
             args:
@@ -54,7 +54,7 @@ presubmits:
         preset-quay-credentials: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:v20190716-842415b
+          - image: quay.io/pusher/builder:v20190729-d71ced0
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/wave/wave-postsubmits.yaml
+++ b/config/jobs/wave/wave-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+  image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/wave/wave-presubmits.yaml
+++ b/config/jobs/wave/wave-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+  image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17,7 +17,7 @@ data:
         timeout: 7200000000000 # 2h
         grace_period: 15000000000 # 15s
         utility_images:
-          clonerefs: "quay.io/pusher/clonerefs:v20190401-6a7e3ff"
+          clonerefs: "quay.io/pusher/clonerefs:v20190729-d71ced0"
           initupload: "gcr.io/k8s-prow/initupload:v20190615-f3db6c682"
           entrypoint: "gcr.io/k8s-prow/entrypoint:v20190615-f3db6c682"
           sidecar: "gcr.io/k8s-prow/sidecar:v20190615-f3db6c682"

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -20,7 +20,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+      image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -62,7 +62,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+      image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -203,7 +203,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -631,7 +631,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190716-842415b
+      image: quay.io/pusher/python-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -671,7 +671,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190716-842415b
+      image: quay.io/pusher/python-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -738,7 +738,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -779,7 +779,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -869,7 +869,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190716-842415b
+      image: quay.io/pusher/python-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -909,7 +909,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190716-842415b
+      image: quay.io/pusher/python-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -976,7 +976,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1017,7 +1017,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1107,7 +1107,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1147,7 +1147,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190716-842415b
+      image: quay.io/pusher/golang-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1239,7 +1239,7 @@ data:
             preset-quay-credentials: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:v20190716-842415b
+              - image: quay.io/pusher/builder:v20190729-d71ced0
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1262,7 +1262,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+              - image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
                 name: verify-config
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1283,7 +1283,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+              - image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
                 name: verify-image-tags
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1307,7 +1307,7 @@ data:
             preset-quay-credentials: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:v20190716-842415b
+              - image: quay.io/pusher/builder:v20190729-d71ced0
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1336,7 +1336,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+      image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1377,7 +1377,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190716-842415b
+      image: quay.io/pusher/kubebuilder-builder:v20190729-d71ced0
       name: runner
       command: ["/usr/local/bin/runner"]
 


### PR DESCRIPTION
This updates the builder images to the latest versions and updates clonerefs to include the new `nslookup` network check from #61 