### PR TITLE
Minor fixups to `builder` image

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -149,7 +149,7 @@ RUN npm install -g snyk
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo && \
     rm -rf /var/lib/apt/lists/*
-RUN echo "prow ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN echo "prow ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/prow && chmod 0440 /etc/sudoers.d/prow
 RUN useradd -rm -d /home/prow -s /bin/bash -g root -G sudo,docker -u 1000 prow
 RUN chown prow:root /workspace \
     && chmod g+s /workspace

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -67,6 +67,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python-setuptools \
     python3-setuptools \
+    python-wheel \
+    python3-wheel \
     rsync \
     unzip \
     wget \

--- a/images/builder/runner
+++ b/images/builder/runner
@@ -23,12 +23,12 @@ cleanup_binfmt_misc() {
     # TODO(bentheelder): if this logic is moved out and made more general
     # we need to check that the host actually has binfmt_misc support first.
     if [ ! -f /proc/sys/fs/binfmt_misc/status ]; then
-        mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+        sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
     fi
     # https://www.kernel.org/doc/html/v4.13/admin-guide/binfmt-misc.html
     # You can remove one entry or all entries by echoing -1
     # to /proc/.../the_name or /proc/sys/fs/binfmt_misc/status.
-    echo -1 >/proc/sys/fs/binfmt_misc/status
+    echo -1 | sudo tee /proc/sys/fs/binfmt_misc/status > /dev/null
     # list entries
     ls -al /proc/sys/fs/binfmt_misc
 }


### PR DESCRIPTION
I noticed that the `cleanup_binfmt_misc` function in the `runner` script was erroring on every single build, so had a go at fixing that, and then noticed a bunch of Python related errors while building the `builder` image, so I fixed them as well.

While fiddling around I also noticed how we manage `sudo` access for the `prow` user and moved it into a separate file rather than messing with `/etc/sudoers` (which really should only be edited with `visudo`). Guess it doesn't really make a huge difference for Docker images, but more to please my mind :see_no_evil:.