### PR TITLE
Add Kubernetes 1.14 PreSubmit to Wave

### DIFF
--- a/config/jobs/wave/wave-presubmits.yaml
+++ b/config/jobs/wave/wave-presubmits.yaml
@@ -73,6 +73,16 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(build|all)(?:.*? )?$"
       rerun_command: "/test build"
 
+    - name: pull-wave-test-1.14
+      <<: *job_template
+      spec:
+        containers:
+          - <<: *container_template_large
+            args:
+              - touch .env && make prepare-env-1.14 && make test
+      trigger: "(?m)^/test (?:.*? )?(1\\.14|all)(?: .*?)?$"
+      rerun_command: "/test 1.14"
+
     - name: pull-wave-test-1.13
       <<: *job_template
       spec:
@@ -92,16 +102,6 @@ presubmits:
               - touch .env && make prepare-env-1.12 && make test
       trigger: "(?m)^/test (?:.*? )?(1\\.12|all)(?: .*?)?$"
       rerun_command: "/test 1.12"
-
-    - name: pull-wave-test-1.11
-      <<: *job_template
-      spec:
-        containers:
-          - <<: *container_template_large
-            args:
-              - touch .env && make prepare-env-1.11 && make test
-      trigger: "(?m)^/test (?:.*? )?(1\\.11|all)(?: .*?)?$"
-      rerun_command: "/test 1.11"
 
     - name: pull-wave-build-docker
       <<: *job_template

--- a/images/kubebuilder-builder/Dockerfile
+++ b/images/kubebuilder-builder/Dockerfile
@@ -33,10 +33,12 @@ RUN sudo mkdir -p \
 		/usr/local/kubebuilder-1.11/bin \
 		/usr/local/kubebuilder-1.12/bin \
 		/usr/local/kubebuilder-1.13/bin \
+		/usr/local/kubebuilder-1.14/bin \
 		&& sudo chown prow:root \
 		/usr/local/kubebuilder-1.11/bin \
 		/usr/local/kubebuilder-1.12/bin \
-		/usr/local/kubebuilder-1.13/bin
+		/usr/local/kubebuilder-1.13/bin \
+		/usr/local/kubebuilder-1.14/bin
 RUN make \
 		dep \
 		ginkgo-cli \
@@ -45,6 +47,7 @@ RUN make \
 		kubebuilder-tools-1.11 \
 		kubebuilder-tools-1.12 \
 		kubebuilder-tools-1.13 \
+		kubebuilder-tools-1.14 \
 		&& rm Makefile
 
-ENV PATH=/usr/local/kubebuilder-1.13/bin:$PATH
+ENV PATH=/usr/local/kubebuilder-1.14/bin:$PATH

--- a/images/kubebuilder-builder/Makefile
+++ b/images/kubebuilder-builder/Makefile
@@ -22,30 +22,37 @@ kustomize:
 	 	go get -u sigs.k8s.io/kustomize/cmd/kustomize; \
 	fi
 
+.PHONY: kubebuilder-tools-1.14
+kubebuilder-tools-1.14:
+	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[0-9]\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9+])?"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
+	if [ "$$ver" != "2.0.0-beta.0" ]; then \
+	  kubebuilder_version=2.0.0-beta.0 kubernetes_version=1.14 make install-kubebuilder-tools; \
+	fi
+
 .PHONY: kubebuilder-tools-1.13
 kubebuilder-tools-1.13:
-	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[0-9]\.[0-9]+\.[0-9]+"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
+	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[0-9]\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9+])?"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
 	if [ "$$ver" != "1.0.8" ]; then \
 	  kubebuilder_version=1.0.8 kubernetes_version=1.13 make install-kubebuilder-tools; \
 	fi
 
 .PHONY: kubebuilder-tools-1.12
 kubebuilder-tools-1.12:
-	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[0-9]\.[0-9]+\.[0-9]+"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
+	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[[0-9]\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9+])?"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
 	if [ "$$ver" != "1.0.7" ]; then \
 	  kubebuilder_version=1.0.7 kubernetes_version=1.12 make install-kubebuilder-tools; \
 	fi
 
 .PHONY: kubebuilder-tools-1.11
 kubebuilder-tools-1.11:
-	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[0-9]\.[0-9]+\.[0-9]+"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
+	@ ver=$$(kubebuilder version | awk '{where = match($$0, /KubeBuilderVersion:"[0-9]\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9+])?"/); if (where != 0) print substr($$0, RSTART+20, RLENGTH)}' | sed s/\",.\*// ); \
 	if [ "$$ver" != "1.0.5" ]; then \
 	  kubebuilder_version=1.0.5 kubernetes_version=1.11 make install-kubebuilder-tools; \
 	fi
 
 # latest stable version
-kubebuilder_version ?= 1.0.8
-kubernetes_version ?= 1.13
+kubebuilder_version ?= 2.0.0-beta.0
+kubernetes_version ?= 1.14
 os := $(shell uname | awk '{print tolower($$0)}')
 # Version string should be approx v1.x.x_linux_amd64
 kubebuilder_version_string=$(kubebuilder_version)_$(os)_amd64

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -1483,6 +1483,16 @@ data:
           trigger: "(?m)^/test (?:.*? )?(build|all)(?:.*? )?$"
           rerun_command: "/test build"
 
+        - name: pull-wave-test-1.14
+          <<: *job_template
+          spec:
+            containers:
+              - <<: *container_template_large
+                args:
+                  - touch .env && make prepare-env-1.14 && make test
+          trigger: "(?m)^/test (?:.*? )?(1\\.14|all)(?: .*?)?$"
+          rerun_command: "/test 1.14"
+
         - name: pull-wave-test-1.13
           <<: *job_template
           spec:
@@ -1502,16 +1512,6 @@ data:
                   - touch .env && make prepare-env-1.12 && make test
           trigger: "(?m)^/test (?:.*? )?(1\\.12|all)(?: .*?)?$"
           rerun_command: "/test 1.12"
-
-        - name: pull-wave-test-1.11
-          <<: *job_template
-          spec:
-            containers:
-              - <<: *container_template_large
-                args:
-                  - touch .env && make prepare-env-1.11 && make test
-          trigger: "(?m)^/test (?:.*? )?(1\\.11|all)(?: .*?)?$"
-          rerun_command: "/test 1.11"
 
         - name: pull-wave-build-docker
           <<: *job_template


### PR DESCRIPTION
https://github.com/pusher/wave/pull/60 Adds 1.14 dependencies to Wave and a target for Kubebuilder tools for version 1.14, this Presubmit will therefore run the tests against a 1.14 API to ensure compatibility