### PR TITLE
Improve Docker Build times by caching multi-stage docker builds

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -58,10 +58,7 @@ clonerefs: docker-build-clonerefs
 ###
 
 docker-build-%:
-	# Use `-` to ignore the exit code from the pull below.
-	# If we can't pull we just have no cache to start from.
-	- docker pull $(REPO)/$*:$(VERSION)
-	docker build --build-arg IMAGE_ARG=$(REPO)/$*:$(VERSION) --build-arg VERSION=$(VERSION) --cache-from $(REPO)/$*:$(VERSION) -t $(REPO)/$*:$(VERSION) $*
+	./docker-build.sh --version=$(VERSION) --build-root=$*
 	@echo "\033[36mBuilt $(REPO)/$*:$(VERSION)\033[0m"
 
 # Set the tags parameter if it is unset or empty
@@ -69,6 +66,8 @@ ifeq ($(TAGS),)
 TAGS := ${VERSION},latest
 endif
 docker-push-%: docker-build-% docker-tag-%
+	./push-stages.sh --build-root=$*
+	@echo "\033[36mPushing $(REPO)/$*:$(VERSION)\033[0m"
 	@IFS=","; tags=${TAGS}; for tag in $${tags}; do docker push $(REPO)/$*:$${tag} && echo "\033[36mPushed $(REPO)/$*:$${tag}\033[0m"; done
 
 docker-tag-%: docker-build-%

--- a/images/docker-build.sh
+++ b/images/docker-build.sh
@@ -49,13 +49,9 @@ fi
 # Check if the image is a multi stage build
 #
 ###########################################
-lines=$(cat ${build_root}/Dockerfile | grep 'FROM')
+lines=$(grep 'FROM .* AS' ${build_root}/Dockerfile)
 declare -a stages
 while read -r from; do
-  # Skip FROMs that aren't named
-  if [[ ! $from =~ "AS" ]]; then
-    continue
-  fi
   stage=$(echo $from | sed -E 's|FROM .* AS (.*)$|\1|')
   stages+=($stage)
 done <<< "$lines"

--- a/images/docker-build.sh
+++ b/images/docker-build.sh
@@ -58,7 +58,6 @@ done <<< "$lines"
 
 for stage in "${stages[@]}"; do
   echo -e "${CYAN}Building Docker pre-stage: ${build_root}:${stage}${NC}"
-  # silently pull the stages cache
   docker pull ${repository}/${build_root}:stage-${stage}
   img=$repository/${build_root}
   docker build --pull --build-arg IMAGE_ARG=${img}:${version} --build-arg VERSION=${version} --cache-from ${img}:stage-${stage} -t ${img}:stage-${stage} --target ${stage} ${build_root}

--- a/images/docker-build.sh
+++ b/images/docker-build.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+repository="quay.io/pusher"
+
+for arg in "$@"; do
+  case ${arg%%=*} in
+    "--version")
+      version="${arg##*=}"
+      ;;
+   "--build-root")
+      build_root="${arg##*=}"
+      ;;
+    "--help")
+      printf "${GREEN}$0${NC}\n"
+      printf "  available options:\n"
+      printf "  --version=${BLUE}<image version tag>${NC}\n"
+      printf "  --build-root=${BLUE}<docker build root>${NC}\n"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      exit 2
+      ;;
+    esac
+done
+
+##############################################################################
+#
+# Use build cache from the given version if it exists, else use the latest tag
+#
+##############################################################################
+curl --location --fail --silent --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+"http://quay.io/v2/pusher/$build_root/manifests/$version" &> /dev/null
+if [ $? != 0 ]; then
+  # Tag does not exist, cache from latest
+  cache_tag="latest"
+else
+  # Tag exists, cahce from this version
+  cache_tag=$version
+fi
+
+###########################################
+#
+# Check if the image is a multi stage build
+#
+###########################################
+lines=$(cat ${build_root}/Dockerfile | grep 'FROM')
+declare -a stages
+while read -r from; do
+  # Skip FROMs that aren't named
+  if [[ ! $from =~ "AS" ]]; then
+    continue
+  fi
+  stage=$(echo $from | sed -E 's|FROM .* AS (.*)$|\1|')
+  stages+=($stage)
+done <<< "$lines"
+
+for stage in "${stages[@]}"; do
+  echo -e "${CYAN}Building Docker pre-stage: ${build_root}:${stage}${NC}"
+  # silently pull the stages cache
+  docker pull ${repository}/${build_root}:stage-${stage}
+  img=$repository/${build_root}
+  docker build --pull --build-arg IMAGE_ARG=${img}:${version} --build-arg VERSION=${version} --cache-from ${img}:stage-${stage} -t ${img}:stage-${stage} --target ${stage} ${build_root}
+  stage_cache_from+="--cache-from $img:stage-$stage "
+done
+
+
+
+# cache_tag should always exists so now we can pull it
+docker pull $repository/${build_root}:$cache_tag
+
+########################
+#
+# Build the docker image
+#
+########################
+echo -e "${CYAN}Building Docker image: ${build_root}${NC}"
+img=${repository}/${build_root}
+docker build --pull --build-arg IMAGE_ARG=${img}:${version} --build-arg VERSION=${version} --cache-from ${img}:${version} ${stage_cache_from} -t ${img}:${version} ${build_root}

--- a/images/push-stages.sh
+++ b/images/push-stages.sh
@@ -31,13 +31,9 @@ done
 # Check if the image is a multi stage build
 #
 ###########################################
-lines=$(cat ${build_root}/Dockerfile | grep 'FROM')
+lines=$(grep 'FROM .* AS' ${build_root}/Dockerfile)
 declare -a stages
 while read -r from; do
-  # Skip FROMs that aren't named
-  if [[ ! $from =~ "AS" ]]; then
-    continue
-  fi
   stage=$(echo $from | sed -E 's|FROM .* AS (.*)$|\1|')
   stages+=($stage)
 done <<< "$lines"

--- a/images/push-stages.sh
+++ b/images/push-stages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+repository="quay.io/pusher"
+
+for arg in "$@"; do
+  case ${arg%%=*} in
+   "--build-root")
+      build_root="${arg##*=}"
+      ;;
+    "--help")
+      printf "${GREEN}$0${NC}\n"
+      printf "  available options:\n"
+      printf "  --build-root=${BLUE}<docker build root>${NC}\n"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      exit 2
+      ;;
+    esac
+done
+
+
+###########################################
+#
+# Check if the image is a multi stage build
+#
+###########################################
+lines=$(cat ${build_root}/Dockerfile | grep 'FROM')
+declare -a stages
+while read -r from; do
+  # Skip FROMs that aren't named
+  if [[ ! $from =~ "AS" ]]; then
+    continue
+  fi
+  stage=$(echo $from | sed -E 's|FROM .* AS (.*)$|\1|')
+  stages+=($stage)
+done <<< "$lines"
+
+#####################
+#
+# Push any pre-stages
+#
+#####################
+for stage in "${stages[@]}"; do
+  echo -e "${CYAN}Pushing Docker pre-stage: ${build_root}:${stage}${NC}"
+  docker push ${repository}/${build_root}:stage-${stage}
+done


### PR DESCRIPTION
This PR introduces a script which builds and tags any multi-stage builds so that we can reduce the time required to rebuild a particular image by caching the multiple stages of any multi-stage builds