### PR TITLE
Add ./configure to the k8s-spot-rescheduler postsubmit

### DIFF
--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
@@ -36,9 +36,9 @@ postsubmits:
         containers:
           - <<: *container_template_large
             args:
-              - touch .env; # No config necessary
+              - ./configure &&
               - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
               - PUSH_TAGS=${TAGS}
-              - touch .env && make docker-build docker-tag docker-push
+              - make docker-build docker-tag docker-push
             securityContext:
               privileged: true

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -763,10 +763,10 @@ data:
             containers:
               - <<: *container_template_large
                 args:
-                  - touch .env; # No config necessary
+                  - ./configure &&
                   - TAGS=${PULL_BASE_REF},${PULL_BASE_SHA},latest
                   - PUSH_TAGS=${TAGS}
-                  - touch .env && make docker-build docker-tag docker-push
+                  - make docker-build docker-tag docker-push
                 securityContext:
                   privileged: true
   k8s-spot-rescheduler_k8s-spot-rescheduler-presubmits.yaml: |


### PR DESCRIPTION
This should fix the failing postsubmit prow job for the k8s-spot-rescheduler.