### PR TITLE
 Update image tags to v20190821-328974b

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ check-image-tags:
 	scripts/check-image-tags.sh
 	@ echo # Produce a new line at the end of each target to help readability
 
-TAG ?= v20190801-3bf82c1
+TAG ?= v20190821-328974b
 .PHONY:
 update-image-tags:
 	@ $(ECHO) "\033[36m\033[1mUpdating image tags\033[0m"

--- a/config/README.md
+++ b/config/README.md
@@ -44,7 +44,7 @@ Since most jobs should use one of the builder images from the [images](../images
 folder, the image tag for these images should stay the same, eg:
 
 ```
-quay.io/pusher/builder:v20190801-3bf82c1
+quay.io/pusher/builder:v20190821-328974b
 ```
 
 Image tags are currently checked in CI and will be enforced to the version in

--- a/config/jobs/faros/faros-postsubmits.yaml
+++ b/config/jobs/faros/faros-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+  image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/faros/faros-presubmits.yaml
+++ b/config/jobs/faros/faros-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+  image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/git-store/git-store-presubmits.yaml
+++ b/config/jobs/git-store/git-store-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190801-3bf82c1
+  image: quay.io/pusher/python-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
+++ b/config/jobs/k8s-spot-price-monitor/k8s-spot-price-monitor-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190801-3bf82c1
+  image: quay.io/pusher/python-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-presubmits.yaml
+++ b/config/jobs/k8s-spot-rescheduler/k8s-spot-rescheduler-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-postsubmits.yaml
+++ b/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190801-3bf82c1
+  image: quay.io/pusher/python-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-presubmits.yaml
+++ b/config/jobs/k8s-spot-termination-handler/k8s-spot-termination-handler-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/python-builder:v20190801-3bf82c1
+  image: quay.io/pusher/python-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/prom-rule-reloader/prom-rule-reloader-postsubmits.yaml
+++ b/config/jobs/prom-rule-reloader/prom-rule-reloader-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/prom-rule-reloader/prom-rule-reloader-presubmits.yaml
+++ b/config/jobs/prom-rule-reloader/prom-rule-reloader-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/quack/quack-postsubmits.yaml
+++ b/config/jobs/quack/quack-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/quack/quack-presubmits.yaml
+++ b/config/jobs/quack/quack-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+  image: quay.io/pusher/golang-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/testing/testing-postsubmits.yaml
+++ b/config/jobs/testing/testing-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
         preset-quay-credentials: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:v20190801-3bf82c1
+          - image: quay.io/pusher/builder:v20190821-328974b
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+          - image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
             name: verify-config
             command: ["/usr/local/bin/runner"]
             args:
@@ -30,7 +30,7 @@ presubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+          - image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
             name: verify-image-tags
             command: ["/usr/local/bin/runner"]
             args:
@@ -54,7 +54,7 @@ presubmits:
         preset-quay-credentials: "true"
       spec:
         containers:
-          - image: quay.io/pusher/builder:v20190801-3bf82c1
+          - image: quay.io/pusher/builder:v20190821-328974b
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:

--- a/config/jobs/wave/wave-postsubmits.yaml
+++ b/config/jobs/wave/wave-postsubmits.yaml
@@ -11,7 +11,7 @@ job_template: &job_template
     - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+  image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/config/jobs/wave/wave-presubmits.yaml
+++ b/config/jobs/wave/wave-presubmits.yaml
@@ -7,7 +7,7 @@ job_template: &job_template
   decorate: true
 
 container_template: &container_template
-  image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+  image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
   name: runner
   command: ["/usr/local/bin/runner"]
 

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -20,7 +20,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+      image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -62,7 +62,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+      image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -203,7 +203,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -631,7 +631,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190801-3bf82c1
+      image: quay.io/pusher/python-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -671,7 +671,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190801-3bf82c1
+      image: quay.io/pusher/python-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -738,7 +738,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -779,7 +779,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -869,7 +869,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190801-3bf82c1
+      image: quay.io/pusher/python-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -909,7 +909,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/python-builder:v20190801-3bf82c1
+      image: quay.io/pusher/python-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -976,7 +976,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1017,7 +1017,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1107,7 +1107,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1147,7 +1147,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/golang-builder:v20190801-3bf82c1
+      image: quay.io/pusher/golang-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1239,7 +1239,7 @@ data:
             preset-quay-credentials: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:v20190801-3bf82c1
+              - image: quay.io/pusher/builder:v20190821-328974b
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1283,7 +1283,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+              - image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
                 name: verify-config
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1304,7 +1304,7 @@ data:
           decorate: true
           spec:
             containers:
-              - image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+              - image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
                 name: verify-image-tags
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1328,7 +1328,7 @@ data:
             preset-quay-credentials: "true"
           spec:
             containers:
-              - image: quay.io/pusher/builder:v20190801-3bf82c1
+              - image: quay.io/pusher/builder:v20190821-328974b
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
@@ -1376,7 +1376,7 @@ data:
         - ^v?\d+\.\d+\.\d+(-rc\d+)?$
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+      image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 
@@ -1417,7 +1417,7 @@ data:
       decorate: true
 
     container_template: &container_template
-      image: quay.io/pusher/kubebuilder-builder:v20190801-3bf82c1
+      image: quay.io/pusher/kubebuilder-builder:v20190821-328974b
       name: runner
       command: ["/usr/local/bin/runner"]
 


### PR DESCRIPTION
Update image tags to v20190821-328974b.

Adds `python3-venv` to images. Fixes broken linter jobs.