### PR TITLE
Use Go Modules for installing Checkconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ verify-config: $(GOPATH)/bin/checkconfig
 
 $(GOPATH)/bin/checkconfig:
 	@ $(ECHO) "\033[36mInstalling checkconfig\033[0m"
-	GO111MODULE=on go get k8s.io/test-infra/prow/cmd/checkconfig
+	GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GO111MODULE=on go get k8s.io/test-infra/prow/cmd/checkconfig
 	@ echo # Produce a new line at the end of each target to help readability
 
 .PHONY:

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ verify-config: $(GOPATH)/bin/checkconfig
 
 $(GOPATH)/bin/checkconfig:
 	@ $(ECHO) "\033[36mInstalling checkconfig\033[0m"
-	go get k8s.io/test-infra/prow/cmd/checkconfig
-	go install k8s.io/test-infra/prow/cmd/checkconfig
+	GO111MODULE=on go get k8s.io/test-infra/prow/cmd/checkconfig
 	@ echo # Produce a new line at the end of each target to help readability
 
 .PHONY:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ verify-config: $(GOPATH)/bin/checkconfig
 
 $(GOPATH)/bin/checkconfig:
 	@ $(ECHO) "\033[36mInstalling checkconfig\033[0m"
-	GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GO111MODULE=on go get k8s.io/test-infra/prow/cmd/checkconfig
+	# Change away from code directory so as not to modify the Go Modules files
+	cd; GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GO111MODULE=on go install k8s.io/test-infra/prow/cmd/checkconfig
 	@ echo # Produce a new line at the end of each target to help readability
 
 .PHONY:


### PR DESCRIPTION
Prow has recently removed the `vendor` directory and now to get `checkconfig` to install properly, you need to use Go Modules.