### PR TITLE
Ensure checkconfig is installed from within test-infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,10 @@ verify-config: $(GOPATH)/bin/checkconfig
 
 $(GOPATH)/bin/checkconfig:
 	@ $(ECHO) "\033[36mInstalling checkconfig\033[0m"
-	# Change away from code directory so as not to modify the Go Modules files
-	cd; GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GO111MODULE=on go install k8s.io/test-infra/prow/cmd/checkconfig
+	mkdir -p $$GOPATH/src/k8s.io
+	# Clone the test-infra source so that we can use the proper go.mod
+	cd $$GOPATH/src/k8s.io; git clone https://github.com/kubernetes/test-infra
+	cd $$GOPATH/src/k8s.io/test-infra; GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GO111MODULE=on go install k8s.io/test-infra/prow/cmd/checkconfig
 	@ echo # Produce a new line at the end of each target to help readability
 
 .PHONY:


### PR DESCRIPTION
Installing checkconfig using go modules is prone to breaking unless we use the proper go.mod file which locks dependencies from with the test-infra repo

`go get` doesn't do this by default so we have to force it to use the test-infra `go.mod` by being inside the repo when we call `go install`