### PR TITLE
Update golangci-lint to support go 1.13

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -28,7 +28,7 @@ based projects within Prow.
 
 The Golang builder contains the following:
 - Everything in the base builder image
-- Golang 1.12.7
+- Golang 1.13.5
 - [profile](github.com/pkg/profile)
 - [delve](github.com/go-delve/delve)
 - [dep](github.com/golang/dep)

--- a/images/golang-builder/Dockerfile
+++ b/images/golang-builder/Dockerfile
@@ -97,7 +97,7 @@ RUN go get github.com/go-delve/delve/cmd/dlv
 # Install dep for dependencies
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 # Install golangci-lint for linting
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
 # Install ginkgo for running tests
 RUN go get github.com/onsi/ginkgo/ginkgo
 


### PR DESCRIPTION
golangci-lint 1.15 doesn't like go 1.13