### PR TITLE
images: add yamllint

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -29,11 +29,11 @@ all: build
 #
 ####
 
-build: builder golang-builder kubebuilder-builder clonerefs python-builder ruby-builder admin-builder
+build: builder golang-builder kubebuilder-builder clonerefs python-builder ruby-builder admin-builder yamllint
 
-tag: docker-tag-builder docker-tag-golang-builder docker-tag-kubebuilder-builder docker-tag-clonerefs docker-tag-python-builder docker-tag-ruby-builder docker-tag-admin-builder
+tag: docker-tag-builder docker-tag-golang-builder docker-tag-kubebuilder-builder docker-tag-clonerefs docker-tag-python-builder docker-tag-ruby-builder docker-tag-admin-builder docker-tag-yamllint
 
-push: docker-push-builder docker-push-golang-builder docker-push-kubebuilder-builder docker-push-clonerefs docker-push-python-builder docker-push-ruby-builder docker-push-admin-builder
+push: docker-push-builder docker-push-golang-builder docker-push-kubebuilder-builder docker-push-clonerefs docker-push-python-builder docker-push-ruby-builder docker-push-admin-builder docker-push-yamllint
 
 ####
 #
@@ -54,6 +54,8 @@ ruby-builder: builder docker-build-ruby-builder
 admin-builder: builder docker-build-admin-builder
 
 clonerefs: docker-build-clonerefs
+
+yamllint: docker-build-yamllint
 
 ####
 #

--- a/images/yamllint/Dockerfile
+++ b/images/yamllint/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.8-alpine3.11
+ENV PYTHON_UNBUFFERED 1
+RUN pip3 install yamllint==1.23.0

--- a/tekton/pipelines/testing/post-builder-images.yaml
+++ b/tekton/pipelines/testing/post-builder-images.yaml
@@ -100,3 +100,18 @@ spec:
       value: "true"
     - name: VERSION
     - name: TAGS
+
+  - name: build-yamllint
+    taskRef:
+      name: testing-build-image
+    resources:
+      inputs:
+      - name: testing
+        resource: testing
+    params:
+    - name: image
+      value: yamllint
+    - name: DOCKER_IN_DOCKER_ENABLED
+      value: "true"
+    - name: VERSION
+    - name: TAGS

--- a/tekton/pipelines/testing/pull-builder-images.yaml
+++ b/tekton/pipelines/testing/pull-builder-images.yaml
@@ -117,3 +117,20 @@ spec:
       value: pull-${params.PULL_NUMBER}
     - name: TAGS
       value: pull-${params.PULL_NUMBER},${params.PULL_PULL_SHA}
+
+  - name: build-yamllint
+    taskRef:
+      name: testing-build-image
+    resources:
+      inputs:
+      - name: testing
+        resource: testing
+    params:
+    - name: image
+      value: yamllint
+    - name: DOCKER_IN_DOCKER_ENABLED
+      value: "true"
+    - name: VERSION
+      value: pull-${params.PULL_NUMBER}
+    - name: TAGS
+      value: pull-${params.PULL_NUMBER},${params.PULL_PULL_SHA}


### PR DESCRIPTION
Since the `yamllint` image we are using is not available across both docker.io and quay.io, 
we want to have our own version of it, so that we can mirror it to both.