### PR TITLE
images: add dhall-builder

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -29,11 +29,11 @@ all: build
 #
 ####
 
-build: builder golang-builder kubebuilder-builder clonerefs python-builder ruby-builder admin-builder yamllint
+build: builder golang-builder kubebuilder-builder clonerefs python-builder ruby-builder dhall-builder admin-builder yamllint
 
-tag: docker-tag-builder docker-tag-golang-builder docker-tag-kubebuilder-builder docker-tag-clonerefs docker-tag-python-builder docker-tag-ruby-builder docker-tag-admin-builder docker-tag-yamllint
+tag: docker-tag-builder docker-tag-golang-builder docker-tag-kubebuilder-builder docker-tag-clonerefs docker-tag-python-builder docker-tag-ruby-builder docker-tag-dhall-builder docker-tag-admin-builder docker-tag-yamllint
 
-push: docker-push-builder docker-push-golang-builder docker-push-kubebuilder-builder docker-push-clonerefs docker-push-python-builder docker-push-ruby-builder docker-push-admin-builder docker-push-yamllint
+push: docker-push-builder docker-push-golang-builder docker-push-kubebuilder-builder docker-push-clonerefs docker-push-python-builder docker-push-ruby-builder docker-push-dhall-builder docker-push-admin-builder docker-push-yamllint
 
 ####
 #
@@ -50,6 +50,8 @@ kubebuilder-builder: golang-builder docker-build-kubebuilder-builder
 python-builder: builder docker-build-python-builder
 
 ruby-builder: builder docker-build-ruby-builder
+
+dhall-builder: builder docker-build-dhall-builder
 
 admin-builder: builder docker-build-admin-builder
 

--- a/images/dhall-builder/Dockerfile
+++ b/images/dhall-builder/Dockerfile
@@ -14,7 +14,7 @@
 
 #############################################################################
 ###
-### %NAME% BUILDER - FROM pusher/builder with %NAME% tooling
+### DHALL BUILDER - FROM pusher/builder with Dhall tooling
 ###
 #############################################################################
 

--- a/images/dhall-builder/Dockerfile
+++ b/images/dhall-builder/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2020 Pusher Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#############################################################################
+###
+### %NAME% BUILDER - FROM pusher/builder with %NAME% tooling
+###
+#############################################################################
+
+ARG VERSION=latest
+ARG REPOSITORY=docker.io/pusher
+FROM ${REPOSITORY}/builder:${VERSION}
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+ARG DHALL_VERSION=1.33.1
+
+# Switch to root user to perform installation
+USER root
+
+RUN apt-get install -yq jq curl wget
+
+RUN curl -sL https://api.github.com/repos/dhall-lang/dhall-haskell/releases/tags/${DHALL_VERSION} | jq -r '.assets[].browser_download_url' | wget -qi -  \
+    && ls -1 dhall-*-x86_64-linux.tar.bz2 | xargs -n1 tar --extract --bzip2 -C /usr/local/bin --strip-components=2 -f \
+    && rm -rf *.tar.bz2 *.zip
+
+# Switch back to prow user
+USER prow


### PR DESCRIPTION
It adds a new `dhall-builder` image to compile config from Dhall templates.