### PR TITLE
Pre-cache commonly used Dhall packages

### DIFF
--- a/images/dhall-builder/Dockerfile
+++ b/images/dhall-builder/Dockerfile
@@ -26,7 +26,7 @@ FROM ${REPOSITORY}/builder:${VERSION}
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
-ARG DHALL_VERSION=1.33.1
+ARG DHALL_VERSION=1.34.0
 
 # Switch to root user to perform installation
 USER root

--- a/images/dhall-builder/Dockerfile
+++ b/images/dhall-builder/Dockerfile
@@ -37,5 +37,10 @@ RUN curl -sL https://api.github.com/repos/dhall-lang/dhall-haskell/releases/tags
     && ls -1 dhall-*-x86_64-linux.tar.bz2 | xargs -n1 tar --extract --bzip2 -C /usr/local/bin --strip-components=2 -f \
     && rm -rf *.tar.bz2 *.zip
 
+# Pre-cache commonly used Dhall packages
+COPY ["pre-cache", "/usr/local/bin/dhall-pre-cache"]
+
+RUN /usr/local/bin/dhall-pre-cache
+
 # Switch back to prow user
 USER prow

--- a/images/dhall-builder/pre-cache
+++ b/images/dhall-builder/pre-cache
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+urls=(
+  https://prelude.dhall-lang.org/v17.0.0/package.dhall
+  https://prelude.dhall-lang.org/v17.1.0/package.dhall
+  https://prelude.dhall-lang.org/v18.0.0/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v4.0.0/package.dhall
+  https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/f4bf4b9ddf669f7149ec32150863a93d6c4b3ef1/package.dhall
+)
+
+for url in "${urls[@]}"; do
+  echo "caching '$url'" >&2
+  dhall hash <<< "$url"
+done


### PR DESCRIPTION
It currently takes a while to initialise Dhall jobs, so let's try and cache the commonly used packages to speed it up.