### PR TITLE
Use a script for pushing images to multiple repos

### DIFF
--- a/config/jobs/testing/testing-postsubmits.yaml
+++ b/config/jobs/testing/testing-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
             name: build-docker
             command: ["/usr/local/bin/runner"]
             args:
-              - "REPOSITORY=quay.io/pusher make --directory=images push && REPOSITORY=docker.io/pusher make --directory=images push"
+              - ./scripts/push-images.sh
             resources:
               requests:
                 cpu: 1

--- a/config/jobs/testing/testing-presubmits.yaml
+++ b/config/jobs/testing/testing-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
             args:
               - VERSION=pull-${PULL_NUMBER}
               - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
-              - "REPOSITORY=quay.io/pusher make --directory=images push && REPOSITORY=docker.io/pusher make --directory=images push"
+              - ./scripts/push-images.sh
             resources:
               requests:
                 cpu: 1

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -1618,7 +1618,7 @@ data:
                 name: build-docker
                 command: ["/usr/local/bin/runner"]
                 args:
-                  - "REPOSITORY=quay.io/pusher make --directory=images push && REPOSITORY=docker.io/pusher make --directory=images push"
+                  - ./scripts/push-images.sh
                 resources:
                   requests:
                     cpu: 1
@@ -1760,7 +1760,7 @@ data:
                 args:
                   - VERSION=pull-${PULL_NUMBER}
                   - TAGS=pull-${PULL_NUMBER},${PULL_PULL_SHA}
-                  - "REPOSITORY=quay.io/pusher make --directory=images push && REPOSITORY=docker.io/pusher make --directory=images push"
+                  - ./scripts/push-images.sh
                 resources:
                   requests:
                     cpu: 1

--- a/scripts/push-images.sh
+++ b/scripts/push-images.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a repositories=(quay.io/pusher docker.io/pusher)
+
+for repository in "${repositories[@]}"; do
+  env REPOSITORY="$repository" make --directory=images push
+done


### PR DESCRIPTION
While I was testing #112 I noticed that the images that are pushed to Docker Hub were tagged with `v<date>-<sha>` instead of `pull-XXX`. I remember @damdo having some issues with getting the `&&` to work properly so I moved the logic for pushing to multiple repositories to a script instead.