### PR TITLE
Update Dhall to v1.35.0

### DIFF
--- a/images/dhall-builder/Dockerfile
+++ b/images/dhall-builder/Dockerfile
@@ -26,7 +26,7 @@ FROM ${REPOSITORY}/builder:${VERSION}
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
-ARG DHALL_VERSION=1.34.0
+ARG DHALL_VERSION=1.35.0
 
 # Switch to root user to perform installation
 USER root

--- a/images/dhall-builder/pre-cache
+++ b/images/dhall-builder/pre-cache
@@ -6,6 +6,7 @@ urls=(
   https://prelude.dhall-lang.org/v17.0.0/package.dhall
   https://prelude.dhall-lang.org/v17.1.0/package.dhall
   https://prelude.dhall-lang.org/v18.0.0/package.dhall
+  https://prelude.dhall-lang.org/v19.0.0/package.dhall
   https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/v4.0.0/package.dhall
   https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/f4bf4b9ddf669f7149ec32150863a93d6c4b3ef1/package.dhall
 )


### PR DESCRIPTION
Dhall v1.35.0 seems to be working _better_ on my machine, it uses half of the memory (measured by eyeballing `htop`) and compiles things faster compared to v1.34.0.