### PR TITLE
Update Dhall to v1.36.0

### DIFF
--- a/images/dhall-builder/Dockerfile
+++ b/images/dhall-builder/Dockerfile
@@ -26,7 +26,7 @@ FROM ${REPOSITORY}/builder:${VERSION}
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
 
-ARG DHALL_VERSION=1.35.0
+ARG DHALL_VERSION=1.36.0
 
 # Switch to root user to perform installation
 USER root


### PR DESCRIPTION
A new release of Dhall is out: https://github.com/dhall-lang/dhall-haskell/releases/tag/1.36.0