### PR TITLE
Lock gobuilder dependency versions

### DIFF
--- a/images/golang-builder/Dockerfile
+++ b/images/golang-builder/Dockerfile
@@ -100,14 +100,14 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 # Install golangci-lint for linting
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
 # Install ginkgo for running tests
-RUN go get github.com/onsi/ginkgo/ginkgo
+RUN GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@v1.14.0
 
 # Install more lint and code generation tools
 RUN go get golang.org/x/tools/cmd/goimports \
     && go get github.com/kisielk/errcheck \
     && go get github.com/gordonklaus/ineffassign \
-    && go get github.com/fzipp/gocyclo \
-    && go get honnef.co/go/tools/... \
+    && GO111MODULE=on go get github.com/fzipp/gocyclo@v0.3.0 \
+    && GO111MODULE=on go get honnef.co/go/tools/...@2020.1.6 \
     && go get golang.org/x/lint/golint \
     && go get gopkg.in/golang/mock.v1/gomock \
     && go get gopkg.in/golang/mock.v1/mockgen

--- a/images/python-builder/Dockerfile
+++ b/images/python-builder/Dockerfile
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y \
 #####################################
 
 # Tools for linting
-RUN pip install flake8 pylint
+RUN pip install flake8
+RUN pip install pylint==1.9.5 lazy-object-proxy==1.4.1
 RUN pip3 install flake8 pylint
 
 


### PR DESCRIPTION
I recently pushed to this project which kicked off a build for the first time since 2020. Since then it seems that many of the go dependencies have upgraded past go v1.16 without leaving the packages backward compatible with the previous GOPATH 'everything should be backward compatible' idea. This commit updates the docker image to build specific version of some pacakages. I have used version numbers from just before our last successful build of this project.
