### PR TITLE
Disallow access to /config

### DIFF
--- a/prow/ingress.yaml
+++ b/prow/ingress.yaml
@@ -7,8 +7,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-production
-    nginx.org/server-snippets: |
-      location /config {
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ^~ /config {
+       
         return 404;
       }
 spec:


### PR DESCRIPTION
The previous configuration had two issue:

- Wrong annotation prefix
- Nginx location prefix was being superseeded by later regex match (using ^~ to force precedence)
