### PR TITLE
Add oauth to restrict access

### DIFF
--- a/prow/ingress.yaml
+++ b/prow/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
     certmanager.k8s.io/cluster-issuer: letsencrypt-production
     nginx.ingress.kubernetes.io/server-snippet: |
       location ^~ /config {
@@ -21,6 +23,30 @@ spec:
               serviceName: deck
               servicePort: 8080
             path: /
+  tls:
+    - hosts:
+        - prow.pusher.com
+      secretName: prow-tls
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: prow-hook
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ^~ /config {
+       
+        return 404;
+      }
+spec:
+  rules:
+    - host: prow.pusher.com
+      http:
+        paths:
           - backend:
               serviceName: hook
               servicePort: 8888
@@ -29,3 +55,24 @@ spec:
     - hosts:
         - prow.pusher.com
       secretName: prow-tls
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+  namespace: kube-system
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: prow.pusher.com
+    http:
+      paths:
+      - path: /oauth2
+        pathType: Prefix
+        backend:
+          serviceName: oauth2-proxy
+          servicePort: 4180
+  tls:
+  - hosts:
+    - prow.pusher.com
+    secretName: prow-tls

--- a/prow/oauth.yaml
+++ b/prow/oauth.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: oauth2-proxy
+    spec:
+      containers:
+      - args:
+        - --provider=github
+        - --email-domain=*
+        - --upstream=file:///dev/null
+        - --http-address=0.0.0.0:4180
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          value: 977e92980c613689b71b
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oauth-secret
+              key:  OAUTH2_PROXY_CLIENT_SECRET
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oauth-secret
+              key:  OAUTH2_PROXY_COOKIE_SECRET
+        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        imagePullPolicy: Always
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 4180
+    protocol: TCP
+    targetPort: 4180
+  selector:
+    k8s-app: oauth2-proxy


### PR DESCRIPTION
prow.pusher.com is currently publically available. I have pushed oauth proxy to disable this. Ahmad created a new oauth app within the Pusher github org, so anyone who with access to github can access prow. This commit has already been applied to prod.
